### PR TITLE
Implemented User Sign-In Authentication in Backend Using JWT Tokens

### DIFF
--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -1,0 +1,12 @@
+export const CLIPS = "clips"
+export const BLOGS = "blogs"
+
+export const WEEKDAYS = {
+    0: 'Sunday',
+    1: 'Monday',
+    2: 'Tuesday',
+    3: 'Wednesday',
+    4: 'Thursday',
+    5: 'Friday',
+    6: 'Saturday'
+  }

--- a/client/src/utils/userUtils.js
+++ b/client/src/utils/userUtils.js
@@ -2,7 +2,6 @@ const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000'
 
 import axios from 'axios'
 
-
 // Tracks if landing page submission is login or register
 export const OPTIONS = {
     LOGIN : "login",
@@ -10,37 +9,76 @@ export const OPTIONS = {
 }
 
 // Handle login/register submission
-export const handleLoginRegister = (formData, submissionType, setIsSuccessful) => {
+export const handleLoginOrRegister = (formData, submissionType, setIsSuccessful) => {
     const username = formData.get("username"), password = formData.get("password")
 
-    submissionType == OPTIONS.LOGIN      && login(username, password, setIsSuccessful)
-    submissionType == OPTIONS.REGISTER   && register(username, password, setIsSuccessful)
+    switch (submissionType) {
+        case OPTIONS.LOGIN:
+            login(username, password, setIsSuccessful)
+            break
 
-    if (submissionType != OPTIONS.LOGIN && submissionType != OPTIONS.REGISTER) {
-        console.error("Invalid type for handleLoginRegister")
+        case OPTIONS.REGISTER:
+            register(username, password, setIsSuccessful)
+            break
+
+        default:
+            console.error("Invalid type for handleLoginRegister")
     }
 }
 
+// Handle login: store token and user in session storage on completion
 export const login = (username, password, setIsSuccessful) => {
     axios.post(`${baseUrl}/users/login`, {username, password})
         .then(res => {
-            console.log("Login successful!")
             setIsSuccessful(res.data.isSuccessful)
+            sessionStorage.setItem("webtoken", res.data.token)
+            sessionStorage.setItem("user", res.data.user)
         })
-        .catch(err => {
-            console.log("Login failed!")
+        .catch(error => {
             setIsSuccessful(false)
         })
 }
 
+// Handle registration: store token and new user in session storage on completion
 export const register = (username, password, setIsSuccessful) => {
     axios.post(`${baseUrl}/users/register`, {username, password})
         .then(res => {
-            console.log("Registration successful!")
             setIsSuccessful(res.data.isSuccessful)
+            sessionStorage.setItem("webtoken", res.data.token)
+
+            const newUser = res.data.newUser
+            // No need to store password in session
+            newUser.remove("password")
+            sessionStorage.setItem("user", newUser)
         })
-        .catch(err => {
-            console.log("Registration failed!")
+        .catch(error => {
             setIsSuccessful(false)
         })
+}
+
+// Verify user access to protected resource
+// Sets hasAccess to true if access is verified, false otherwise
+export const verifyAccess = (setHasAccess) => {
+
+    const token = sessionStorage.getItem("webtoken")
+
+    if (!token) {
+        setHasAccess(false)
+    }
+
+    axios.get(`${baseUrl}/auth/verify`, {headers : { 'Authorization' : `Bearer ${token}` }})
+        .then(res => {
+            const isSuccessful = res.data.isSuccessful
+            if (isSuccessful) {
+                setHasAccess(true)
+            }
+            else {
+                setHasAccess(false)
+            }
+        })
+        .catch(error => {
+            setHasAccess(false)
+        })
+
+
 }

--- a/client/src/utils/userUtils.js
+++ b/client/src/utils/userUtils.js
@@ -64,6 +64,7 @@ export const verifyAccess = (setHasAccess) => {
 
     if (!token) {
         setHasAccess(false)
+        return
     }
 
     axios.get(`${baseUrl}/auth/verify`, {headers : { 'Authorization' : `Bearer ${token}` }})

--- a/client/src/utils/userUtils.js
+++ b/client/src/utils/userUtils.js
@@ -69,13 +69,7 @@ export const verifyAccess = (setHasAccess) => {
 
     axios.get(`${baseUrl}/auth/verify`, {headers : { 'Authorization' : `Bearer ${token}` }})
         .then(res => {
-            const isSuccessful = res.data.isSuccessful
-            if (isSuccessful) {
-                setHasAccess(true)
-            }
-            else {
-                setHasAccess(false)
-            }
+            setHasAccess(res.data.isSuccessful)
         })
         .catch(error => {
             setHasAccess(false)

--- a/client/src/utils/weekdays.js
+++ b/client/src/utils/weekdays.js
@@ -1,9 +1,0 @@
-export const WEEKDAYS = {
-  0: 'Sunday',
-  1: 'Monday',
-  2: 'Tuesday',
-  3: 'Wednesday',
-  4: 'Thursday',
-  5: 'Friday',
-  6: 'Saturday'
-}

--- a/server/index.js
+++ b/server/index.js
@@ -1,28 +1,16 @@
 const express = require('express')
-const session = require('express-session')
 const cors = require('cors')
 
 const usersRouter = require('./routes/users')
-
-const sessionConfig = {
-    name: 'sessionId',
-    secret: 'very secret',
-    cookie: {
-        maxAge: 1000 * 60 * 5,
-        secure: process.env.RENDER ? true : false,
-        httpOnly: false,
-    },
-    resave: false,
-    saveUninitialized: false,
-}
+const authRouter = require('./routes/auth')
 
 const app = express()
 
 app.use(express.json())
-app.use(session(sessionConfig))
 app.use(cors())
 
 app.use('/users', usersRouter)
+app.use('/auth', authRouter)
 
 const PORT = 3000
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "bcryptjs": "^3.0.2",
+        "jsonwebtoken": "^9.0.2",
         "nodemon": "^3.1.10",
         "prisma": "^6.10.1"
       }
@@ -222,6 +223,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -382,6 +390,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -814,6 +832,101 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "bcryptjs": "^3.0.2",
+    "jsonwebtoken": "^9.0.2",
     "nodemon": "^3.1.10",
     "prisma": "^6.10.1"
   }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -15,9 +15,8 @@ router.use('/verify', async (req, res) => {
             if (error) {
                 return res.status(STATUS_CODES.UNAUTHORIZED).json({ message: error.message, isSuccessful: false })
             }
-            else {
-                return res.status(STATUS_CODES.OK).json({ message: 'Token verified successfully', isSuccessful: true })
-            }
+
+            return res.status(STATUS_CODES.OK).json({ message: 'Token verified successfully', isSuccessful: true })
         })
 
     } catch (error) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,28 @@
+const router = require('express').Router()
+
+const webtoken = require('jsonwebtoken')
+const TOKEN_SECRET = process.env.TOKEN_SECRET
+
+const STATUS_CODES = require('../statusCodes')
+
+router.use('/verify', async (req, res) => {
+    try {
+        // Extract the JWT token from the request header
+        const token = req.headers.authorization.split(' ')[1]
+
+        // Verify the token
+        webtoken.verify(token, TOKEN_SECRET, (error, user) => {
+            if (error) {
+                return res.status(STATUS_CODES.UNAUTHORIZED).json({ message: error.message, isSuccessful: false })
+            }
+            else {
+                return res.status(STATUS_CODES.OK).json({ message: 'Token verified successfully', isSuccessful: true })
+            }
+        })
+
+    } catch (error) {
+        return res.status(STATUS_CODES.SERVER_ERROR).json({ message: error.message, isSuccessful: false })
+    }
+})
+
+module.exports = router

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -8,6 +8,7 @@ const STATUS_CODES = require('../statusCodes')
 router.use('/verify', async (req, res) => {
     try {
         // Extract the JWT token from the request header
+        // TODO Find better way to accomplish this
         const token = req.headers.authorization.split(' ')[1]
 
         // Verify the token


### PR DESCRIPTION
Key functionality: Leveraged JSON web tokens to store user info and authentication token in client-side session storage after a successful login or registration. The client will now leverage a /verify route to confirm access to a desired resource before redirecting to it, otherwise defaulting to a 401 page on failure.

Additional features: As previously suggested and arguably needed, CLIPS, BLOGS, and WEEKDAYS have been merged into a single constants file that all related components reference; handleLoginRegister has been refactored into handleLogin_or_Register and now consists of a switch statement that defaults to a console error to determine which action to take; some of my error catches were stylized as "err" and are now written fully as "error" for my own readability

A successful call to /auth/verify when user accesses Home Page after signing in
![Image 6-26-25 at 12 24 PM](https://github.com/user-attachments/assets/489622e8-83d7-42c6-b4cb-49a611f4d3e6)

Here is an example response of what invoking /auth/verify with a faulty token may look like. As with other routes, the boolean isSuccessful serves as an indicator to take alternative action, in this case redirection to a 401 Unauthorized page.
![Image 6-26-25 at 12 29 PM](https://github.com/user-attachments/assets/d6177f7a-9bec-4443-bcbd-7031d21dfda4)

Helper function verifyAccess is also configured so that invoking the /auth/verify route is avoided altogether if no token exists in the session storage. Here is a preview of the HTML React will render in that situation or if the token is simply invalid:
   ```
     <Route path='/unauthorized' element={<>
          <p>Snaked! <em>(401 Unauthorized)</em></p>
          <p>Unable to verify access, please sign back in.</p>
          <Link to='/'>Go Back</Link>
        </> } />
```
