### PR TITLE
[TC1][Viewing Recommendations] Recommendations visible clientside

### DIFF
--- a/client/src/main/HomePage/HomePostsView.jsx
+++ b/client/src/main/HomePage/HomePostsView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, act } from 'react'
+import { useState, useEffect, useContext } from 'react'
 import { Link } from 'react-router';
 
 import PostCard from '/src/main/PostCard'
@@ -6,7 +6,6 @@ import PostCard from '/src/main/PostCard'
 import UserContext from '/src/utils/UserContext'
 import { HOME_PAGE_POST_COUNT, HOME_ORIGIN } from '/src/utils/constants'
 import  { getAllPostsByType } from '/src/utils/postUtils'
-import { scorePosts } from '/src/utils/recUtils'
 
 import '/src/css/home.css'
 
@@ -15,13 +14,14 @@ const HomePostsView = ({ postType }) => {
 
     const postType_lowercase = postType.toLowerCase()
     const [posts, setPosts] = useState(null)
+    const [isInitialized, setIsInitialized] = useState(false)
 
     useEffect( () => {
-        getAllPostsByType(postType, setPosts)
+        getAllPostsByType(postType, setPosts, { isScoring: true, activeUser })
+        setIsInitialized(true)
     }, [])
-    useEffect( () => {
-        scorePosts(posts, activeUser)
-    }, [posts])
+
+    if (!isInitialized) return (<p>Loading...</p>)
 
     return(<>
         <div id={`home_${postType_lowercase}`} className="column" >

--- a/client/src/main/Posts.jsx
+++ b/client/src/main/Posts.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useContext } from 'react'
 import { useNavigate } from 'react-router'
 
 import Header from './Header'
@@ -6,6 +6,7 @@ import Sidebar from './Sidebar'
 import Footer from './Footer'
 import PostCard from './PostCard'
 
+import UserContext from '/src/utils/UserContext'
 import { verifyAccess } from '/src/utils/UserUtils'
 import  { getAllPostsByType } from '/src/utils/postUtils'
 import { POSTS } from '/src/utils/constants'
@@ -14,6 +15,7 @@ import '/src/css/hasSidebar.css'
 import '/src/css/posts.css'
 
 const Posts = ({ postType }) => {
+    const { activeUser } = useContext(UserContext)
 
     const navigate = useNavigate()
     const [hasAccess, setHasAccess] = useState(null)
@@ -29,7 +31,7 @@ const Posts = ({ postType }) => {
 
     useEffect( () => {
         setIsReadyToDisplayContent(false)
-        getAllPostsByType(postType, setPosts)
+        getAllPostsByType(postType, setPosts, { isScoring: true, activeUser })
         setIsReadyToDisplayContent(true)
     }, [postType])
 
@@ -46,8 +48,8 @@ const Posts = ({ postType }) => {
             <section className='postsContent'>
                 <form className='postsHeader'>
                     <select name='filter'>
-                        <option value='latest'>Latest Content</option>
                         <option value='recommended'>Recommended</option>
+                        <option value='latest'>Latest Content</option>
                         <option value='popular'>Popular</option>
                         <option value='near'>Near You</option>
                     </select>

--- a/client/src/utils/PostUtils.js
+++ b/client/src/utils/PostUtils.js
@@ -3,6 +3,7 @@ const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000'
 import axios from 'axios'
 import { tokenize } from './recUtils.js'
 import { LIKE, UNLIKE } from './constants.js'
+import { scorePosts } from './recUtils.js'
 
 // Uploads a post, starting with the file attachment to GCS and then the full post data to server
 // Updates user's posts array state when complete
@@ -40,10 +41,15 @@ export const getUserPostsByType = async ( activeUser, postType, setUserPosts ) =
 }
 
 // Gets all posts by specified postType and sets the posts array state
-export const getAllPostsByType = async ( postType, setPosts ) => {
+// If scoringPayload is provided, will score the posts for the provided user and set the posts array state
+export const getAllPostsByType = async ( postType, setPosts, scoringPayload = { isScoring: false, activeUser: null } ) => {
     await axios.get(`${baseUrl}/posts/all/${postType}`)
         .then(res => {
-            setPosts(res.data.posts.toSorted((a, b) => new Date(b.creationDate) - new Date(a.creationDate)))
+            if (scoringPayload.isScoring) {
+                scorePosts(res.data.posts, scoringPayload.activeUser, setPosts)
+            } else {
+                setPosts(res.data.posts.toSorted((a, b) => new Date(b.creationDate) - new Date(a.creationDate)))
+            }
         })
         .catch(error => {
             console.error("getUserPostsByType error: ", error)

--- a/client/src/utils/recUtils.js
+++ b/client/src/utils/recUtils.js
@@ -103,7 +103,6 @@ export const scorePosts = async (posts, activeUser, setPosts) => {
         return b.score - a.score
     })
 
-    console.log(posts)
     await setPosts(posts)
 }
 


### PR DESCRIPTION
### Overview
Following the implementation of scoring posts...
- the Home page now displays recommended posts on sign-in (see #17)
- the Clips and Blogs pages default to recommended posts
once filtering is added, users can swap between these recommended posts and other unbiased categories
- recommending posts verifiably do _not_ have an effect on posts visible on the Profile page, as a profile should just contain the full breadth of a user's posts

### Test Plan
[Video demonstration](https://www.loom.com/share/373702f675d341f3a98b1657eff8231c?sid=50019ae7-a608-4440-ac64-4f95156c4eba) of recommended content being displayed on sign-in. The Clips and Blogs pages visibly show this same content by default, while the Profile page includes _all_ posts from the user (which happens to be every post in the app, at the moment)