### PR TITLE
[TC1][Scoring] Video Length as a Factor in Post Length Bias

### DIFF
--- a/client/src/main/Posts.jsx
+++ b/client/src/main/Posts.jsx
@@ -87,15 +87,8 @@ const Posts = ({ postType }) => {
                 </form>
 
                 <div className="posts">
-                { filterState !== POPULAR &&
+                {
                     posts?.map(post => {
-                        return (
-                            <PostCard key={post.postID} post={post} postType={postType} origin={POSTS[postType]} />
-                        )
-                    })
-                }
-                { filterState === POPULAR &&
-                    posts?.toSorted((a,b) => b.popularity - a.popularity).map(post => {
                         return (
                             <PostCard key={post.postID} post={post} postType={postType} origin={POSTS[postType]} />
                         )

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -52,8 +52,9 @@ export const AGE_CUTOFF_IN_DAYS = 7
 export const LIKE_WEIGHT = 0.1
 export const COMMENT_WEIGHT = 0.33
 export const CLIP_DESCRIPTION_WEIGHT = 0.33
-export const AVERAGE_WORDS_READ_PER_MINUTE = 230
-export const SECONDS_IN_MINUTE = 60
+const AVERAGE_WORDS_READ_PER_MINUTE = 230
+const SECONDS_IN_MINUTE = 60
+export const AVERAGE_WORDS_READ_PER_SECOND = AVERAGE_WORDS_READ_PER_MINUTE / SECONDS_IN_MINUTE
 
 export const RECOMMENDED = "recommended"
 export const LATEST = 'latest'

--- a/client/src/utils/recommendationUtils.js
+++ b/client/src/utils/recommendationUtils.js
@@ -104,6 +104,7 @@ export const scorePosts = async (posts, activeUser, setPosts, isByPopularity) =>
         let postLength = new String(post.description).split(NON_ALPHANUMERIC_REGEX).length
         if (post.type === CLIPS) {
             const res = await axios.post(`${baseUrl}/posts/clipLength`, { fileURL : post.fileURL})
+                .catch(error => console.error(error))
             const clipLength = res.data.clipLength
             const clipLengthAsWordCount = Math.ceil(clipLength * AVERAGE_WORDS_READ_PER_SECOND)
             postLength += clipLengthAsWordCount

--- a/client/src/utils/recommendationUtils.js
+++ b/client/src/utils/recommendationUtils.js
@@ -157,7 +157,11 @@ const calculateBiasFactors = async (activeUser) => {
 
         if (post?.type === CLIPS) {
             likedClips++
-            // TODO Implement advanced video length logic
+            const res = await axios.post(`${baseUrl}/posts/clipLength`, { fileURL : post.fileURL})
+                .catch(error => console.error(error))
+            const clipLength = res.data.clipLength
+            const clipLengthAsWordCount = Math.ceil(clipLength * AVERAGE_WORDS_READ_PER_SECOND)
+            totalLikedContentLength += clipLengthAsWordCount
         }
         else if (post?.type === BLOGS) {
             likedBlogs++

--- a/client/src/utils/recommendationUtils.js
+++ b/client/src/utils/recommendationUtils.js
@@ -45,10 +45,9 @@ export const tokenize = async (post, activeUser, action) => {
 export const scorePosts = async (posts, activeUser, setPosts, isByPopularity) => {
     const userFrequency = activeUser.user_Frequency
 
-    // If the user has never liked a post, return
-    // NOTE: Wouldn't a better way to check this just be to query likedPosts array?
-    if (!userFrequency) {
-        return
+    // If the user has never liked a post, manually override the isByPopularity flag to true
+    if (activeUser.likedPosts.length === 0) {
+        isByPopularity = true
     }
 
     // Currently disabled to allow for testing

--- a/client/src/utils/recommendationUtils.js
+++ b/client/src/utils/recommendationUtils.js
@@ -110,6 +110,8 @@ export const scorePosts = async (posts, activeUser, setPosts, isByPopularity) =>
             postLength += clipLengthAsWordCount
         }
 
+        post["postLength"] = postLength
+
         // Calculate post length bias as percentage difference from average length of liked posts
         const postLengthBias = Math.abs(1 - postLength / avgLengthOfLikedPosts)
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,11 +18,147 @@
       "devDependencies": {
         "@google-cloud/storage": "^7.16.0",
         "bcryptjs": "^3.0.2",
+        "get-video-duration": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.1",
         "nodemon": "^3.1.10",
         "prisma": "^6.10.1"
       }
+    },
+    "node_modules/@ffprobe-installer/darwin-arm64": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/darwin-arm64/-/darwin-arm64-5.0.1.tgz",
+      "integrity": "sha512-vwNCNjokH8hfkbl6m95zICHwkSzhEvDC3GVBcUp5HX8+4wsX10SP3B+bGur7XUzTIZ4cQpgJmEIAx6TUwRepMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "LGPL-2.1",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffprobe-installer/darwin-x64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/darwin-x64/-/darwin-x64-5.0.0.tgz",
+      "integrity": "sha512-Zl0UkZ+wW/eyMKBPLTUCcNQch2VDnZz/cBn1DXv3YtCBVbYd9aYzGj4MImdxgWcoE0+GpbfbO6mKGwMq5HCm6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ffprobe-installer/ffprobe": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/ffprobe/-/ffprobe-1.4.1.tgz",
+      "integrity": "sha512-3WJvxU0f4d7IOZdzoVCAj9fYtiQNC6E0521FJFe9iP5Ej8auTXU7TsrUzIAG1CydeQI+BnM3vGog92SCcF9KtA==",
+      "dev": true,
+      "license": "LGPL-2.1",
+      "optionalDependencies": {
+        "@ffprobe-installer/darwin-arm64": "5.0.1",
+        "@ffprobe-installer/darwin-x64": "5.0.0",
+        "@ffprobe-installer/linux-arm": "5.0.0",
+        "@ffprobe-installer/linux-arm64": "5.0.0",
+        "@ffprobe-installer/linux-ia32": "5.0.0",
+        "@ffprobe-installer/linux-x64": "5.0.0",
+        "@ffprobe-installer/win32-ia32": "5.0.0",
+        "@ffprobe-installer/win32-x64": "5.0.0"
+      }
+    },
+    "node_modules/@ffprobe-installer/linux-arm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm/-/linux-arm-5.0.0.tgz",
+      "integrity": "sha512-mM1PPxP2UX5SUvhy0urcj5U8UolwbYgmnXA/eBWbW78k6N2Wk1COvcHYzOPs6c5yXXL6oshS2rZHU1kowigw7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffprobe-installer/linux-arm64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm64/-/linux-arm64-5.0.0.tgz",
+      "integrity": "sha512-IwFbzhe1UydR849YXLPP0RMpHgHXSuPO1kznaCHcU5FscFBV5gOZLkdD8e/xrcC8g/nhKqy0xMjn5kv6KkFQlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffprobe-installer/linux-ia32": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-ia32/-/linux-ia32-5.0.0.tgz",
+      "integrity": "sha512-c3bWlWEDMST59SAZycVh0oyc2eNS/CxxeRjoNryGRgqcZX3EJWJJQL1rAXbpQOMLMi8to1RqnmMuwPJgLLjjUA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffprobe-installer/linux-x64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-x64/-/linux-x64-5.0.0.tgz",
+      "integrity": "sha512-zgLnWJFvMGCaw1txGtz84sMEQt6mQUzdw86ih9S/kZOWnp06Gj/ams/EXxEkAxgAACCVM6/O0mkDe/6biY5tgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ffprobe-installer/win32-ia32": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-ia32/-/win32-ia32-5.0.0.tgz",
+      "integrity": "sha512-NnDdAZD6ShFXzJeCkAFl2ZjAv7GcJWYudLA+0T/vjZwvskBop+sq1PGfdmVltfFDcdQiomoThRhn9Xiy9ZC71g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ffprobe-installer/win32-x64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-x64/-/win32-x64-5.0.0.tgz",
+      "integrity": "sha512-P4ZMRFxVMnfMsOyTfBM/+nkTodLeOUfXNPo+X1bKEWBiZxRErqX/IHS5sLA0yAH8XmtKZcL7Cu6M26ztGcQYxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "GPL-3.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
@@ -598,6 +734,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -765,6 +916,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/express": {
@@ -1070,6 +1245,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-video-duration": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-video-duration/-/get-video-duration-4.1.0.tgz",
+      "integrity": "sha512-kDmnD/C/WFHmZx7eV2duUNCwAH6w9YwpigiUHmq7cRNmxuTvcJ/otvcxa4A5GDus2iSZ+CZEA5e0va/r5ZWumw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ffprobe-installer/ffprobe": "^1.4.1",
+        "execa": "^5.0.0",
+        "is-stream": "^2.0.0"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1317,6 +1517,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -1415,6 +1625,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jiti": {
       "version": "2.4.2",
@@ -1561,6 +1778,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -1593,6 +1817,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -1815,6 +2049,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1866,6 +2113,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -1889,6 +2152,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2158,6 +2431,29 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -2230,6 +2526,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -2286,6 +2589,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strnum": {
@@ -2516,6 +2829,22 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wrappy": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@google-cloud/storage": "^7.16.0",
     "bcryptjs": "^3.0.2",
+    "get-video-duration": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",
     "nodemon": "^3.1.10",

--- a/server/prisma/migrations/20250713220305_cliplength/migration.sql
+++ b/server/prisma/migrations/20250713220305_cliplength/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "clipLength" DOUBLE PRECISION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -37,6 +37,7 @@ model Post {
   location          String
   type              String
   fileURL           String
+  clipLength        Float?
   likeCount         Int     @default(0)
   comments          String[]  @default([])
 }

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -3,6 +3,7 @@ const router = require('express').Router()
 const STATUS_CODES = require('../statusCodes')
 const { QUICKTIME, MOV } = require('../constants')
 const GCS = require('../utils/GCS')
+const { getVideoDurationInSeconds } = require('get-video-duration')
 
 const Multer = require('multer')
 const multer = Multer({
@@ -252,6 +253,20 @@ router.post('/comments/:postID', async (req, res, next) => {
         comment["author"] = author
 
         return res.status(STATUS_CODES.CREATED).json({ comment, message: 'Comment created' })
+
+    } catch (error) {
+        return res.status(STATUS_CODES.SERVER_ERROR).json({ message: error })
+    }
+})
+
+// POST /posts/clipLength
+// Provided a post's file URL, returns the video length in seconds
+router.post('/clipLength', async (req, res, next) => {
+    try {
+        const { fileURL } = req.body
+        const clipLength = await getVideoDurationInSeconds(fileURL).catch((error) => {console.error(error)})
+
+        res.status(STATUS_CODES.OK).json({ clipLength, message: 'Video length retrieved' })
 
     } catch (error) {
         return res.status(STATUS_CODES.SERVER_ERROR).json({ message: error })


### PR DESCRIPTION
### Overview
The distinction between Clips and Blogs in my app made it seem disingenuous to only account for description lengths when Clips have full videos to view in them.
- When calculating a clip's post length, we pass its fileURL to [a library](https://www.npmjs.com/package/get-video-duration) that calculates its length in seconds
- Using this length, we translate it into a "word count," in the same way we find the word count of the post's description, by multiplying it by the generally agreed on average reading speed in words per minute, converted into words per second. This length is added to the post's overall length in calculations

#### Caveat
Calculating the length of every video each time the feed loads again results in a lot of overhead that slows down the app - a future PR will have updated the backend structure so that the length of a clip is saved in the database on post creation

### Test Plan
**See yellow text on right side of screen representing data for first / second post cards on left
To confirm that a clip's calculated length differs from its description word count and subsequently affects its post length bias standing, I checked their stored post lengths in the component tree. As expected, the visible post length is much more than just its description.
<img width="1626" height="804" alt="image" src="https://github.com/user-attachments/assets/8b71cbb6-3f61-421a-964c-ee3024c43cb8" />
<img width="1610" height="777" alt="image" src="https://github.com/user-attachments/assets/bf347c0e-c99d-4c01-99ed-dfaff7d3a587" />

