### PR TITLE
[Gen] Updates to Fix Routing in Client 

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -40,7 +40,7 @@ function App() {
 
                         <Route path="/blogs" element={<Posts postType={BLOGS} />} />
 
-                        <Route path="/:origin/post/:postID" element={<SinglePost />} />
+                        <Route path="/:origin/:profileID/post/:postID" element={<SinglePost />} />
 
                         <Route
                             path="/unauthorized"

--- a/client/src/main/PostCard.jsx
+++ b/client/src/main/PostCard.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router";
 import { deletePost, handleLikeOrUnlikePost, waitForGCSToFinish } from "/src/utils/postUtils";
 
 import UserContext from "/src/utils/UserContext";
-import { CLIPS, BLOGS, LIKE, UNLIKE } from "/src/utils/constants";
+import { CLIPS, BLOGS, LIKE, UNLIKE, PROFILE_NOT_APPLICABLE } from "/src/utils/constants";
 import { PROFILE_ORIGIN } from "/src/utils/constants";
 
 import "/src/css/postCard.css";
@@ -12,7 +12,7 @@ import trash from "/src/assets/trash.png";
 import emptyheart from "/src/assets/heart.png";
 import fullheart from "/src/assets/heartFull.png";
 
-const PostCard = ({ post, postType, origin, setUserPosts, isSelfProfile = false }) => {
+const PostCard = ({ post, postType, origin, profileID = PROFILE_NOT_APPLICABLE, setUserPosts, isSelfProfile = false }) => {
     const { activeUser, setActiveUser } = useContext(UserContext);
 
     const embedRef = useRef(null);
@@ -60,7 +60,7 @@ const PostCard = ({ post, postType, origin, setUserPosts, isSelfProfile = false 
     }
 
     return (
-        <Link to={`/${origin}/post/${post.postID}`} className="postRedirect">
+        <Link to={`/${origin}/${profileID}/post/${post.postID}`} className="postRedirect">
             <article className={`${postType}PostCard`}>
                 {postType === CLIPS && (
                     <video

--- a/client/src/main/ProfilePage/ProfilePostsView.jsx
+++ b/client/src/main/ProfilePage/ProfilePostsView.jsx
@@ -45,6 +45,7 @@ const ProfilePostView = ({ userToDisplay, activeUser, profileContentView, userPo
                                 post={post}
                                 postType={profileContentView}
                                 origin={PROFILE_ORIGIN}
+                                profileID={userToDisplay?.userID}
                                 setUserPosts={setUserPosts}
                                 isSelfProfile={isSelfProfile}
                             />

--- a/client/src/main/SinglePost.jsx
+++ b/client/src/main/SinglePost.jsx
@@ -7,7 +7,7 @@ import Footer from "./Footer";
 import UserContext from "/src/utils/UserContext";
 import { getUserByID, verifyAccess, refreshUserSession } from "/src/utils/userUtils";
 import { getPostByID, handleLikeOrUnlikePost, getComments, createComment } from "/src/utils/postUtils";
-import { CLIPS, BLOGS, toSingular, ORIGINS, LIKE, UNLIKE } from "/src/utils/constants";
+import { CLIPS, BLOGS, toSingular, ORIGINS, LIKE, UNLIKE, PROFILE_NOT_APPLICABLE } from "/src/utils/constants";
 
 import "/src/css/singlePost.css";
 import emptyheart from "/src/assets/heart.png";
@@ -15,7 +15,7 @@ import fullheart from "/src/assets/heartFull.png";
 
 const SinglePost = () => {
     const { activeUser, setActiveUser } = useContext(UserContext);
-    const { origin, postID } = useParams();
+    const { origin, profileID, postID } = useParams();
 
     const [hasAccess, setHasAccess] = useState(null);
     const [post, setPost] = useState(null);
@@ -129,7 +129,7 @@ const SinglePost = () => {
                     </div>
                 </section>
 
-                <Link to={`/${ORIGINS[origin]}`}>
+                <Link to={`/${ORIGINS[origin]}/${profileID !== PROFILE_NOT_APPLICABLE ? profileID : ""}`}>
                     <p className="goBackButton">Go Back</p>
                 </Link>
             </div>

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -41,6 +41,8 @@ export const ORIGINS = {
     [PROFILE_ORIGIN]: "profile",
 };
 
+export const PROFILE_NOT_APPLICABLE = "_";
+
 export const LIKE = "like";
 export const UNLIKE = "unlike";
 


### PR DESCRIPTION
### Overview
The _Go Back_ button that appears on the single post page to return to the originating redirect would not function correctly if the user clicked on a post from the Profile page. This was the result of the profile page being expanded to allow viewing any user and the _Go Back_ button being improperly configured to adapt to this.

### Test Plan
[Demonstration video](https://github.com/user-attachments/assets/02e9a17b-5d5f-49e3-9df6-7889b4f85ce5
) of user going to profile page, selecting a post, and successfully going back to the profile page
