### PR TITLE
[TC2] Profile Ranking Algorithm Complete

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -7,3 +7,6 @@ node_modules
 node_modules/
 
 sk8rlog.json
+
+__pycache__/
+GoogleNews-vectors-negative300.bin

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,72 @@
+from flask import Flask, request, jsonify
+from gensim.models import KeyedVectors
+from numpy import dot
+from numpy.linalg import norm
+import numpy as np
+
+# Load the Google News word2vec model
+model_path = 'GoogleNews-vectors-negative300.bin'
+model = KeyedVectors.load_word2vec_format(model_path, binary=True)
+
+# Vectorizes each keyword in a user frequency object and averages out all vectors as an embedding for that particualr user
+def vectorize(keywords, frequencies):
+    vectors = []
+    collectiveWeight = 0
+
+    for i, word in enumerate(keywords):
+        if word in model:
+            vector = model[word]
+
+            # Compute weight based on repetition factor and add to collective weight
+            repetitionWeight = 1
+            if frequencies[word]["likedPostsPresentIn"] != 0:
+                repetitionWeight += 1 / (frequencies[word]["totalFrequencyAcrossLikedPosts"] / frequencies[word]["likedPostsPresentIn"])
+            collectiveWeight += repetitionWeight
+
+            # Add vector to list with weight applied
+            vectors.append(vector * repetitionWeight)
+
+        # Otherwise, the word just isn't in the model, nothing to do here (yet?)
+
+    if not vectors or collectiveWeight == 0:
+        return np.zeros(model.vector_size)
+
+    # Average out all vectors as one
+    averageOfVectors = np.sum(vectors, axis=0) / collectiveWeight
+    return averageOfVectors
+
+
+app = Flask(__name__)
+
+# Default
+@app.route("/")
+def root():
+    return "ROOT"
+
+# Create vector embeddings for user and candidate frequency objects and send results in response
+@app.route("/embedUserFrequency", methods=['POST'])
+def embedUserFrequency():
+    data = request.get_json()
+    # Vectorization returns a NumPy array, standardize this to a normal array that can be processed into JSON using tolist()
+    userFrequencyEmbedding = vectorize(data["userKeywords"], data["userFrequency"]).tolist()
+    candidateFrequencyEmbedding = vectorize(data["candidateKeywords"], data["candidateFrequency"]).tolist()
+
+    # Compute cosine similarity score as dot product of embeddings divided by the product of their normal vectorizations
+    userNorm = norm(userFrequencyEmbedding)
+    candidateNorm = norm(candidateFrequencyEmbedding)
+
+    # If either user has never liked a post, fall back to 0
+    if userNorm == 0 or candidateNorm == 0:
+        cosineSimilarityScore = 0
+    else:
+        cosineSimilarityScore = dot(userFrequencyEmbedding, candidateFrequencyEmbedding) / (userNorm * candidateNorm)
+
+    return jsonify({
+        "userFrequencyEmbedding" : userFrequencyEmbedding,
+        "candidateFrequencyEmbedding" : candidateFrequencyEmbedding,
+        "dimension" : len(userFrequencyEmbedding),
+        "cosineSimilarityScore" : cosineSimilarityScore
+    })
+
+if __name__ == "__main__":
+    app.run()

--- a/server/app.py
+++ b/server/app.py
@@ -46,7 +46,9 @@ def root():
 # Create vector embeddings for user and candidate frequency objects and send results in response
 @app.route("/embedUserFrequency", methods=['POST'])
 def embedUserFrequency():
+    # Node translation: data = req.body
     data = request.get_json()
+
     # Vectorization returns a NumPy array, standardize this to a normal array that can be processed into JSON using tolist()
     userFrequencyEmbedding = vectorize(data["userKeywords"], data["userFrequency"]).tolist()
     candidateFrequencyEmbedding = vectorize(data["candidateKeywords"], data["candidateFrequency"]).tolist()
@@ -61,12 +63,14 @@ def embedUserFrequency():
     else:
         cosineSimilarityScore = dot(userFrequencyEmbedding, candidateFrequencyEmbedding) / (userNorm * candidateNorm)
 
+    # Node translation: return res.json()
     return jsonify({
         "userFrequencyEmbedding" : userFrequencyEmbedding,
         "candidateFrequencyEmbedding" : candidateFrequencyEmbedding,
         "dimension" : len(userFrequencyEmbedding),
         "cosineSimilarityScore" : cosineSimilarityScore
     })
+
 
 if __name__ == "__main__":
     app.run()

--- a/server/app.py
+++ b/server/app.py
@@ -8,7 +8,7 @@ import numpy as np
 model_path = 'GoogleNews-vectors-negative300.bin'
 model = KeyedVectors.load_word2vec_format(model_path, binary=True)
 
-# Vectorizes each keyword in a user frequency object and averages out all vectors as an embedding for that particualr user
+# Vectorizes each keyword in a user frequency object and averages out all vectors as an embedding for that particular user
 def vectorize(keywords, frequencies):
     vectors = []
     collectiveWeight = 0

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -38,6 +38,12 @@ router.post("/register", async (req, res) => {
             },
         });
 
+        await prisma.interactionData.create({
+            data: {
+                userID: newUser.userID,
+            },
+        });
+
         const tokenPayload = { userID: newUser.userID, username: newUser.username };
         const token = webtoken.sign(tokenPayload, TOKEN_SECRET, { expiresIn: "1h" });
 

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -36,3 +36,6 @@ export const RANKING_MODES = {
 
 export const FOLLOW = "follow";
 export const UNFOLLOW = "unfollow";
+
+export const POST_OVR_WEIGHT = 0.7;
+export const POPULARITY_OVR_WEIGHT = 0.3;

--- a/server/utils/profileRankingUtils.js
+++ b/server/utils/profileRankingUtils.js
@@ -75,6 +75,6 @@ const evaluateCandidate = async (user, candidate) => {
     mutualFollowFrequency = isNaN(mutualFollowFrequency) ? 0 : mutualFollowFrequency;
 
     // Finalize and return the candidate's score
-    const candidateScore = postOvr * similarityFactor * (1 + mutualFollowFrequency);
+    const candidateScore = baseScore * similarityFactor * (1 + mutualFollowFrequency);
     return candidateScore;
 };


### PR DESCRIPTION
### Overview
In #33, I created and endpoint to test a default output of the profile ranking algorithm. Pursuant to the outline described in [documentation](https://docs.google.com/document/d/1kNEz32Xm4RZwRLB867fBea2WWoBEhev3rD0eiksIfTs/edit?tab=t.0#heading=h.plj4hngf5wup), I implemented comparing users' interests and cross referencing who they follow (#34), henceforth completing the algorithm.

The nature of NLP computation that needs to be performed to compare user interests ushered in the need for some work in Python - it could've all been done in Node, but it's much less common and subsequently makes obtaining concrete documentation and implementation harder than it needs to be. Check out [my findings on this](https://docs.google.com/document/d/1kNEz32Xm4RZwRLB867fBea2WWoBEhev3rD0eiksIfTs/edit?tab=t.0#heading=h.igvtuwiutuj3) for more context on this decision and what's going on in _app.py_

- created a Flask application in Python that serves the sole purpose of generating user frequency object embeddings and calculating cosine similarity scores
- **evaluateCandidate** in _profileRankingUtils_ invokes the Flask endpoint _/embedUserFrequency_, passing in host and candidate keyword arrays and the user_Frequency objects they originated from to generate repetition factor weights
- Using the _gensim_ library, the script loads the Google News Dataset Word2Vec model
- Each keyword in a user input array gets mapped to a vector that subsequently has the repetition factor weight applied to it
- After vectorizing each keyword, the array of vectors is averaged out into a single embedding that "describes" the user's interests
- The host and candidate embeddings are compared using cosine similarity with _numpy_ linear algebra utilities
- The interest embeddings and cosine similarity score are sent back as a response to **evaluateCandidate**, which uses these computations to finalize calculations alongside mutual following frequency
- The _/acquireCandidates_ endpoint subsequently returns data with the same behavior as originally implemented - an array of all candidates in descending order of _candidacyScore_

### Test Plan
Another [test run](https://github.com/user-attachments/assets/13f4f8ce-ba22-40b6-b069-52bbc44883e5) of the _/acquireCandidates_ endpoint, where visibly different candidacy scores are being output now that the whole algorithm has come together. Outside of endpoint functionality, all metrics have been and are being continuously console log tested to ensure functionality as calculations are performed.

