### PR TITLE
[TC2] Notifications Scheduling - Reached Working State

### DIFF
--- a/client/src/utils/clientWebSocketUtils.js
+++ b/client/src/utils/clientWebSocketUtils.js
@@ -8,9 +8,7 @@ export const establishWebSocketConnection = (setNotifications, setHasNewNotifica
     const identifier = new Date().getMilliseconds();
 
     const socket = io(VITE_SERVER_URL);
-    socket.on(CONNECT, () => {
-        console.log(`Websocket connection established at ${new Date().toLocaleTimeString()}`);
-    });
+    socket.on(CONNECT, () => {});
 
     socket.on(DISCONNECT, () => {
         console.log(`disconnected at ${new Date().toLocaleTimeString()}`);

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -24,8 +24,8 @@ Guide to cron interval strings (from node-cron docs):
 To specify an amount at any position, append /<number> to the star (*)
 Leaving all stars (*) will default to every minute
 */
-export const CRON_INTERVAL_STRING = "*/40 * * * * *";
-export const CRON_INTERVAL_DESCRIPTOR = "40 seconds";
+export const CRON_INTERVAL_STRING = "*/15 * * * * *";
+export const CRON_INTERVAL_DESCRIPTOR = "15 seconds";
 
 export const CLIPS = "Clips";
 

--- a/server/utils/notificationSchedulingUtils.js
+++ b/server/utils/notificationSchedulingUtils.js
@@ -1,19 +1,83 @@
 import cron from "node-cron";
-import { CONNECTION, DISCONNECT, DELIVER_NOTIFICATION, CRON_INTERVAL_STRING, CRON_INTERVAL_DESCRIPTOR } from "./constants.js";
+import { toSecondOfDay } from "./sessionUtils.js";
+import {
+    CONNECTION,
+    DISCONNECT,
+    DELIVER_NOTIFICATION,
+    CRON_INTERVAL_STRING,
+    CRON_INTERVAL_DESCRIPTOR,
+    HALF_HOUR_IN_SECONDS,
+    MIDDLE_OF_DAY_IN_SECONDS,
+} from "./constants.js";
+import { PrismaClient } from "../generated/prisma/index.js";
+const prisma = new PrismaClient();
 
 export const requestNotificationScheduling = (socketServer) => {
     console.log(`Cron generated - running a task every ${CRON_INTERVAL_DESCRIPTOR}`);
 
     socketServer.on(CONNECTION, (socket) => {
-        console.log("notiSched utils: connection established");
-
-        cron.schedule(CRON_INTERVAL_STRING, () => {
-            const now = new Date().toLocaleTimeString();
-            socket.emit(DELIVER_NOTIFICATION, `Cron job fired at ${now}`);
+        cron.schedule(CRON_INTERVAL_STRING, async () => {
+            await fireNotifications(socket);
         });
 
         socket.on(DISCONNECT, () => {
             console.log("notiSched utils: connection terminated");
         });
     });
+};
+
+// Gets users to notify and pushes notifications to them
+const fireNotifications = async (socket) => {
+    const now = new Date();
+    const noNotificationsMessage = `No one to notify at ${now.toLocaleTimeString()}`;
+    const usersToNotify = await getUsersToNotify(now);
+
+    usersToNotify.length ? notifyUsers(usersToNotify, socket) : socket.emit(DELIVER_NOTIFICATION, noNotificationsMessage);
+};
+
+// Calculates users' best notification times and queues them to be notified if it falls within the cron job window
+const getUsersToNotify = async (now) => {
+    const nowAsSecondOfDay = toSecondOfDay(now);
+    const halfHourBefore = nowAsSecondOfDay - HALF_HOUR_IN_SECONDS;
+    const halfHourAfter = nowAsSecondOfDay + HALF_HOUR_IN_SECONDS;
+
+    const users = await prisma.user.findMany();
+
+    // Iterate users and calculate best times
+    for (const user of users) {
+        delete user.password;
+        const sessionData = await prisma.sessionData.findUnique({ where: { userID: user.userID } });
+        // const interactionData = await prisma.interactionData.find({ where: { userID: user.userID } });
+
+        // Default user's best time to midday if they have no session logged
+        if (sessionData.sessionCount === 0) {
+            user["bestTime"] = MIDDLE_OF_DAY_IN_SECONDS;
+        } else {
+            user["bestTime"] = Math.ceil(sessionData.averageSessionStartTime + sessionData.averageSessionTime / 2);
+        }
+    }
+
+    // Filter out users whose best time fall out the hour window
+    let notifiableUsers = users.filter((u) => {
+        return u.bestTime >= halfHourBefore && u.bestTime < halfHourAfter;
+    });
+
+    return notifiableUsers;
+};
+
+// Grab top candidate for each user lined up and emit the notification through the WebSocket
+const notifyUsers = async (usersToNotify, socket) => {
+    for (const user of usersToNotify) {
+        let topCandidate;
+
+        // Acquire candidates and pick out top candidate (first in array)
+        const res = await fetch(`http://localhost:3000/recommendations/acquireCandidates/for/${user.userID}`).catch((error) => {
+            console.log(error);
+        });
+        const candidates = await res.json();
+        topCandidate = candidates[0];
+
+        const suggestionMessage = `Suggested for ${user.username}: ${topCandidate.username}`;
+        socket.emit(DELIVER_NOTIFICATION, `${suggestionMessage} | ${new Date().toLocaleTimeString()}`);
+    }
 };

--- a/server/utils/notificationSchedulingUtils.js
+++ b/server/utils/notificationSchedulingUtils.js
@@ -77,7 +77,7 @@ const notifyUsers = async (usersToNotify, socket) => {
         const candidates = await res.json();
         topCandidate = candidates[0];
 
-        const suggestionMessage = `Suggested for ${user.username}: ${topCandidate.username}`;
+        const suggestionMessage = `For @${user.username}: You might be interested in @${topCandidate.username}`;
         socket.emit(DELIVER_NOTIFICATION, `${suggestionMessage} | ${new Date().toLocaleTimeString()}`);
     }
 };

--- a/server/utils/serverWebSocketUtils.js
+++ b/server/utils/serverWebSocketUtils.js
@@ -6,8 +6,6 @@ export const createWebSocket = (server, corsConfig) => {
     const socketServer = new Server(server, { cors: corsConfig });
 
     socketServer.on(CONNECTION, (socket) => {
-        console.log("socket utils: connection established");
-
         socket.on(DISCONNECT, () => {
             console.log("socket utils: connection terminated");
         });

--- a/server/utils/sessionUtils.js
+++ b/server/utils/sessionUtils.js
@@ -6,7 +6,7 @@ const SECONDS_IN_HOUR = MINUTES_IN_HOUR * SECONDS_IN_MINUTE;
 import { LIKE, COMMENT, CREATE } from "./constants.js";
 
 // Converts a date object to a number of seconds since midnight
-const toSecondOfDay = (date) => {
+export const toSecondOfDay = (date) => {
     return date.getHours() * SECONDS_IN_HOUR + date.getMinutes() * SECONDS_IN_MINUTE + date.getSeconds();
 };
 


### PR DESCRIPTION
### Overview
The cron-based notification scheduling system has reached working functionality pursuant to some of the objectives outlined in [documentation](https://docs.google.com/document/d/1kNEz32Xm4RZwRLB867fBea2WWoBEhev3rD0eiksIfTs/edit?tab=t.0#heading=h.5z5nkj7lixr7)

At regular intervals during the server lifespan, we now:
- Sweep the database for all users whose best notification times align with the time the sweep was conducted
-- Leverages a half-hour window of allowance both in the past and present to count in alignment

- For each "notifiable" user, perform a candidate search
- Emit a notification through the WebSocket confirming that candidate Y was successfully suggested to user X

### Completion Plans
- Implement a _recentlySuggestedUsers_ column in the User model to track if it would be redundant to suggest some candidate again because it already happened too recently
- Implement socket rooms for each user signed into the app such that the cron job only fires notifications to the room the suggestion notification actually belongs to

### Current Test Plan
Sample user _@/x_ was deliberately created so that their session data would align with the cron jobs firing at the general time of account creation. 
- Notifications would successfully fire a suggestion to follow _@/z3nL_ while the lower half-hour bound checked out
- However, as the current time exit the lower window bound, notifications expectedly stopped firing, serving as proof of proper time checks and subsequent delivery

Notification logs, in descending order of recency top to bottom
<img width="392" height="190" alt="image" src="https://github.com/user-attachments/assets/41636ba2-be9b-4ce2-a284-d3e9090c563a" />
<img width="388" height="194" alt="image" src="https://github.com/user-attachments/assets/6563b4ee-33dc-4544-be26-39e71a98b515" />

