### PR TITLE
[TC2] Multiple Clients Receive Personalized Notifications Using Socket Rooms

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,7 +9,7 @@ import Posts from "./main/Posts";
 import SinglePost from "./main/SinglePost";
 
 import UserContext from "/src/utils/UserContext.js";
-import { establishWebSocketConnection } from "/src/utils/clientWebSocketUtils.js";
+import { establishWebSocketConnection, joinUserSocketRoom } from "/src/utils/clientWebSocketUtils.js";
 import { CLIPS, BLOGS } from "/src/utils/constants";
 
 import "./App.css";
@@ -18,10 +18,24 @@ function App() {
     const [notifications, setNotifications] = useState([]);
     const [hasNewNotifications, setHasNewNotifications] = useState(false);
     const [activeUser, setActiveUser] = useState({});
+    const [socket, setSocket] = useState(null);
+
+    const connectSocket = async () => {
+        setSocket(await establishWebSocketConnection(setNotifications, setHasNewNotifications, activeUser));
+    };
+
+    const joinRoom = async () => {
+        await joinUserSocketRoom(socket, activeUser);
+    };
 
     useEffect(() => {
-        establishWebSocketConnection(setNotifications, setHasNewNotifications);
+        connectSocket();
     }, []);
+
+    // Join user socket room on successful load
+    useEffect(() => {
+        joinRoom();
+    }, [socket, activeUser]);
 
     return (
         <>

--- a/client/src/utils/clientWebSocketUtils.js
+++ b/client/src/utils/clientWebSocketUtils.js
@@ -1,22 +1,35 @@
 import { io } from "socket.io-client";
 const { VITE_SERVER_URL } = import.meta.env;
-import { CONNECT, DISCONNECT, DELIVER_NOTIFICATION } from "/src/utils/constants.js";
+import { CONNECT, DISCONNECT, DELIVER_NOTIFICATION, ENTER_ROOM } from "/src/utils/constants.js";
 
 // Creates a client socket connection to the server and listens for notifications
-export const establishWebSocketConnection = (setNotifications, setHasNewNotifications) => {
-    // React Strict Mode will create two connections, so we'll give each an arbitrary identifier for visibility
-    const identifier = new Date().getMilliseconds();
-
+export const establishWebSocketConnection = (setNotifications, setHasNewNotifications, activeUser) => {
     const socket = io(VITE_SERVER_URL);
-    socket.on(CONNECT, () => {});
+    socket.on(CONNECT, async () => {
+        console.log(`connected at ${new Date().toLocaleTimeString()}`);
+        await joinUserSocketRoom(socket, activeUser);
+    });
 
     socket.on(DISCONNECT, () => {
         console.log(`disconnected at ${new Date().toLocaleTimeString()}`);
     });
 
     socket.on(DELIVER_NOTIFICATION, (content) => {
-        const notification = `Notification from socket ${identifier}: ${content}`;
+        const notification = `${content}`;
         setNotifications((prev) => [notification, ...prev]);
         setHasNewNotifications(true);
     });
+
+    return socket;
+};
+
+// Joins a socket room for a specified user through their ID
+export const joinUserSocketRoom = async (socket, activeUser) => {
+    if (!socket || !activeUser.userID) {
+        console.log("no socket or activeUser to join room with");
+        return;
+    }
+    const userID = activeUser.userID;
+    await socket.emit(ENTER_ROOM, userID);
+    console.log(`socket ${socket.id} is now in user_${userID}`);
 };

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -65,6 +65,7 @@ export const CONNECT = "connect";
 export const DISCONNECT = "disconnect";
 export const REQUEST_NOTIFICATION = "request notification";
 export const DELIVER_NOTIFICATION = "deliver notification";
+export const ENTER_ROOM = "enter room";
 
 export const FOLLOW = "follow";
 export const UNFOLLOW = "unfollow";

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -9,6 +9,7 @@ export const CONNECTION = "connection";
 export const DISCONNECT = "disconnect";
 export const REQUEST_NOTIFICATION = "request notification";
 export const DELIVER_NOTIFICATION = "deliver notification";
+export const ENTER_ROOM = "enter room";
 
 /*
 Guide to cron interval strings (from node-cron docs):

--- a/server/utils/notificationSchedulingUtils.js
+++ b/server/utils/notificationSchedulingUtils.js
@@ -53,7 +53,7 @@ const getUsersToNotify = async (now) => {
 
 // Grab top candidate for each user lined up and emit the notification through the WebSocket
 const notifyUsers = async (usersToNotify, socketServer) => {
-    for (const user of usersToNotify) {
+    usersToNotify.forEach(async (user) => {
         // Acquire candidates and pick out top candidate (first in array)
         const res = await fetch(`http://localhost:3000/recommendations/acquireCandidates/for/${user.userID}`).catch((error) => {
             console.log(error);
@@ -63,5 +63,5 @@ const notifyUsers = async (usersToNotify, socketServer) => {
 
         const suggestionMessage = `Hey ${user.name || `@${user.username}`}, you might be interested in @${topCandidate.username}`;
         socketServer.to(`user_${user.userID}`).emit(DELIVER_NOTIFICATION, `${suggestionMessage} | ${new Date().toLocaleTimeString()}`);
-    }
+    });
 };

--- a/server/utils/notificationSchedulingUtils.js
+++ b/server/utils/notificationSchedulingUtils.js
@@ -1,45 +1,31 @@
 import cron from "node-cron";
 import { toSecondOfDay } from "./sessionUtils.js";
-import {
-    CONNECTION,
-    DISCONNECT,
-    DELIVER_NOTIFICATION,
-    CRON_INTERVAL_STRING,
-    CRON_INTERVAL_DESCRIPTOR,
-    HALF_HOUR_IN_SECONDS,
-    MIDDLE_OF_DAY_IN_SECONDS,
-} from "./constants.js";
+import { DELIVER_NOTIFICATION, CRON_INTERVAL_STRING, CRON_INTERVAL_DESCRIPTOR, HALF_HOUR_IN_SECONDS, MIDDLE_OF_DAY_IN_SECONDS } from "./constants.js";
 import { PrismaClient } from "../generated/prisma/index.js";
 const prisma = new PrismaClient();
 
 export const requestNotificationScheduling = (socketServer) => {
     console.log(`Cron generated - running a task every ${CRON_INTERVAL_DESCRIPTOR}`);
 
-    socketServer.on(CONNECTION, (socket) => {
-        cron.schedule(CRON_INTERVAL_STRING, async () => {
-            await fireNotifications(socket);
-        });
-
-        socket.on(DISCONNECT, () => {
-            console.log("notiSched utils: connection terminated");
-        });
+    cron.schedule(CRON_INTERVAL_STRING, async () => {
+        await fireNotifications(socketServer);
     });
 };
 
 // Gets users to notify and pushes notifications to them
-const fireNotifications = async (socket) => {
+const fireNotifications = async (socketServer) => {
     const now = new Date();
-    const noNotificationsMessage = `No one to notify at ${now.toLocaleTimeString()}`;
     const usersToNotify = await getUsersToNotify(now);
-
-    usersToNotify.length ? notifyUsers(usersToNotify, socket) : socket.emit(DELIVER_NOTIFICATION, noNotificationsMessage);
+    if (usersToNotify.length > 0) {
+        notifyUsers(usersToNotify, socketServer);
+    }
 };
 
 // Calculates users' best notification times and queues them to be notified if it falls within the cron job window
 const getUsersToNotify = async (now) => {
     const nowAsSecondOfDay = toSecondOfDay(now);
-    const halfHourBefore = nowAsSecondOfDay - HALF_HOUR_IN_SECONDS;
-    const halfHourAfter = nowAsSecondOfDay + HALF_HOUR_IN_SECONDS;
+    const halfHourBefore = nowAsSecondOfDay - 20 * HALF_HOUR_IN_SECONDS;
+    const halfHourAfter = nowAsSecondOfDay + 20 * HALF_HOUR_IN_SECONDS;
 
     const users = await prisma.user.findMany();
 
@@ -47,12 +33,12 @@ const getUsersToNotify = async (now) => {
     for (const user of users) {
         delete user.password;
         const sessionData = await prisma.sessionData.findUnique({ where: { userID: user.userID } });
-        // const interactionData = await prisma.interactionData.find({ where: { userID: user.userID } });
 
         // Default user's best time to midday if they have no session logged
         if (sessionData.sessionCount === 0) {
             user["bestTime"] = MIDDLE_OF_DAY_IN_SECONDS;
         } else {
+            // average midpoint of user's session = start time + (session length / 2)
             user["bestTime"] = Math.ceil(sessionData.averageSessionStartTime + sessionData.averageSessionTime / 2);
         }
     }
@@ -66,18 +52,16 @@ const getUsersToNotify = async (now) => {
 };
 
 // Grab top candidate for each user lined up and emit the notification through the WebSocket
-const notifyUsers = async (usersToNotify, socket) => {
+const notifyUsers = async (usersToNotify, socketServer) => {
     for (const user of usersToNotify) {
-        let topCandidate;
-
         // Acquire candidates and pick out top candidate (first in array)
         const res = await fetch(`http://localhost:3000/recommendations/acquireCandidates/for/${user.userID}`).catch((error) => {
             console.log(error);
         });
         const candidates = await res.json();
-        topCandidate = candidates[0];
+        const topCandidate = candidates[0];
 
-        const suggestionMessage = `For @${user.username}: You might be interested in @${topCandidate.username}`;
-        socket.emit(DELIVER_NOTIFICATION, `${suggestionMessage} | ${new Date().toLocaleTimeString()}`);
+        const suggestionMessage = `Hey ${user.name || `@${user.username}`}, you might be interested in @${topCandidate.username}`;
+        socketServer.to(`user_${user.userID}`).emit(DELIVER_NOTIFICATION, `${suggestionMessage} | ${new Date().toLocaleTimeString()}`);
     }
 };

--- a/server/utils/notificationSchedulingUtils.js
+++ b/server/utils/notificationSchedulingUtils.js
@@ -24,8 +24,8 @@ const fireNotifications = async (socketServer) => {
 // Calculates users' best notification times and queues them to be notified if it falls within the cron job window
 const getUsersToNotify = async (now) => {
     const nowAsSecondOfDay = toSecondOfDay(now);
-    const halfHourBefore = nowAsSecondOfDay - 20 * HALF_HOUR_IN_SECONDS;
-    const halfHourAfter = nowAsSecondOfDay + 20 * HALF_HOUR_IN_SECONDS;
+    const halfHourBefore = nowAsSecondOfDay - HALF_HOUR_IN_SECONDS;
+    const halfHourAfter = nowAsSecondOfDay + HALF_HOUR_IN_SECONDS;
 
     const users = await prisma.user.findMany();
 

--- a/server/utils/profileRankingUtils.js
+++ b/server/utils/profileRankingUtils.js
@@ -48,7 +48,7 @@ const evaluateCandidate = async (user, candidate) => {
     const cosineSimilarityScore = await computeSimilarityScore(user, candidate);
 
     // Convert the similarity score to a scalar factor
-    const similarityFactor = cosineSimilarityScore < 0 ? -1 + cosineSimilarityScore : 1 + cosineSimilarityScore;
+    const similarityFactor = (1 + Math.abs(cosineSimilarityScore)) * (cosineSimilarityScore < 0 ? -1 : 1);
 
     // Find the mutual following frequency between the users
     const mutualFollowFrequency = computeMutualFollowingFrequency(user, candidate);
@@ -106,6 +106,7 @@ const computeSimilarityScore = async (user, candidate) => {
         })
         .catch((err) => {
             console.log(err);
+            cosineSimilarityScore = 0;
         });
 
     return cosineSimilarityScore;
@@ -120,8 +121,7 @@ const computeMutualFollowingFrequency = (user, candidate) => {
 
     // Hold this overlap against all users they follow to create a mutual following factor
     const followingUnion = new Set(userFollowing.concat(candidateFollowing));
-    let mutualFollowFrequency = followingOverlap.length / followingUnion.size;
-    mutualFollowFrequency = isNaN(mutualFollowFrequency) ? 0 : mutualFollowFrequency;
+    const mutualFollowFrequency = followingUnion.size === 0 ? 0 : followingOverlap.length / followingUnion.size;
 
     return mutualFollowFrequency;
 };

--- a/server/utils/serverWebSocketUtils.js
+++ b/server/utils/serverWebSocketUtils.js
@@ -1,17 +1,19 @@
 import { Server } from "socket.io";
-import { CONNECTION, DISCONNECT, REQUEST_NOTIFICATION } from "./constants.js";
+import { CONNECTION, DISCONNECT, REQUEST_NOTIFICATION, ENTER_ROOM } from "./constants.js";
 
 // Creates a websocket server and listens for notification requests
 export const createWebSocket = (server, corsConfig) => {
-    const socketServer = new Server(server, { cors: corsConfig });
+    const socketServer = new Server(server, { connectionStateRecovery: {}, cors: corsConfig });
 
     socketServer.on(CONNECTION, (socket) => {
-        socket.on(DISCONNECT, () => {
-            console.log("socket utils: connection terminated");
-        });
+        socket.on(DISCONNECT, () => {});
 
         socket.on(REQUEST_NOTIFICATION, () => {
             console.log("request notification received from client");
+        });
+
+        socket.on(ENTER_ROOM, (userID) => {
+            socket.join(`user_${userID}`);
         });
     });
 


### PR DESCRIPTION
## Preface
#37 implemented firing follow suggestion notifications at regular intervals for users whose "best times" fell in the allowance window of the cron job. The caveat to this, however, was that the test plan was deliberately structured so that only the _one_ user that was signed in fell within the allowance window during the test so we could easily verify what happens when that user falls out ("nothing", expectedly). 

## Overview
The notification system has been expanded so that multiple users can be signed into the app at the same time and receive follow suggestions personalized to them.
- On connection to the WebSocket server after user sign-in, the client socket instance emits an event to subscribe the server socket instance to a private room marked by the user's userID, stylized "user_ _userID"_

- The cron job runs the same as previously implemented, eventually calling **notifyUsers** if needed. 

- Instead of globally emitting a notification event on completion, **notifyUsers** now emits a notification event to a user through their corresponding channel name.

- If that user is signed in to the application, then their client socket instance will be subscribed to the channel and listening for the notification event, after which it will extract its content and display it in the notifications popup

## Test Plan
### Two-User Display Check
- Remove the best time allowance window so we are guaranteed that _all_ users will receive a notification on cron job occurrence
- Have two browser instances open, each signed into Sk8rlog on a different account to facilitate the test
- Wait for the cron job to run and create a notification
- Both users should receive a notification at approximately the same time, and the message will be personalized for them.

Video of successful run of outlined plan (video starts at AS the notification fires due to file size constraints)
https://github.com/user-attachments/assets/d770476e-697d-4090-9cb2-13ea67238121

