### PR TITLE
[TC2] Tracking a User's Suggested Users To Follow Across Operations

### DIFF
--- a/client/src/utils/clientWebSocketUtils.js
+++ b/client/src/utils/clientWebSocketUtils.js
@@ -6,13 +6,10 @@ import { CONNECT, DISCONNECT, DELIVER_NOTIFICATION, ENTER_ROOM } from "/src/util
 export const establishWebSocketConnection = (setNotifications, setHasNewNotifications, activeUser) => {
     const socket = io(VITE_SERVER_URL);
     socket.on(CONNECT, async () => {
-        console.log(`connected at ${new Date().toLocaleTimeString()}`);
         await joinUserSocketRoom(socket, activeUser);
     });
 
-    socket.on(DISCONNECT, () => {
-        console.log(`disconnected at ${new Date().toLocaleTimeString()}`);
-    });
+    socket.on(DISCONNECT, () => {});
 
     socket.on(DELIVER_NOTIFICATION, (content) => {
         const notification = `${content}`;
@@ -26,10 +23,8 @@ export const establishWebSocketConnection = (setNotifications, setHasNewNotifica
 // Joins a socket room for a specified user through their ID
 export const joinUserSocketRoom = async (socket, activeUser) => {
     if (!socket || !activeUser.userID) {
-        console.log("no socket or activeUser to join room with");
         return;
     }
     const userID = activeUser.userID;
     await socket.emit(ENTER_ROOM, userID);
-    console.log(`socket ${socket.id} is now in user_${userID}`);
 };

--- a/server/prisma/migrations/20250723065344_siggest/migration.sql
+++ b/server/prisma/migrations/20250723065344_siggest/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "suggestedUsers" JSONB NOT NULL DEFAULT '[]';

--- a/server/prisma/migrations/20250723065449_unsuggest/migration.sql
+++ b/server/prisma/migrations/20250723065449_unsuggest/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `suggestedUsers` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "suggestedUsers";

--- a/server/prisma/migrations/20250723065505_sugge2/migration.sql
+++ b/server/prisma/migrations/20250723065505_sugge2/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "suggestedUsers" JSONB;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -15,18 +15,19 @@ datasource db {
 }
 
 model User {
-  userID            String  @id @default(cuid())
+  userID            String      @id @default(cuid())
   name              String?
-  username          String @unique
+  username          String      @unique
   password          String
-  joinDate          DateTime @default(now())
+  joinDate          DateTime    @default(now())
   location          String?
   bio               String?
   profilePicUrl     String?
-  following         String[] @default([])
-  favorites         String[] @default([])
-  likedPosts        String[] @default([])
-  followedUsers     String[] @default([])
+  following         String[]    @default([])
+  favorites         String[]    @default([])
+  likedPosts        String[]    @default([])
+  followedUsers     String[]    @default([])
+  suggestedUsers    Json?
   user_Frequency    Json?
 }
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -28,6 +28,7 @@ router.post("/register", async (req, res) => {
                 password,
                 name,
                 location,
+                suggestedUsers: {},
             },
         });
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -155,6 +155,13 @@ router.put("/:userID/followedUsers/:action", async (req, res, _next) => {
         const { userBeingReferencedID } = req.body;
 
         const user = await prisma.user.findUnique({ where: { userID } });
+
+        // Remove user to follow from suggested users if they're present in it
+        const recentlySuggestedUsers = user.suggestedUsers;
+        if (recentlySuggestedUsers[userBeingReferencedID]) {
+            delete recentlySuggestedUsers[candidate.userID];
+        }
+
         await prisma.user.update({
             where: { userID },
             data: {
@@ -162,6 +169,8 @@ router.put("/:userID/followedUsers/:action", async (req, res, _next) => {
                     action === FOLLOW
                         ? [...user.followedUsers, userBeingReferencedID]
                         : user.followedUsers.filter((uID) => uID !== userBeingReferencedID),
+
+                suggestedUsers: recentlySuggestedUsers,
             },
         });
 

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -59,3 +59,5 @@ export const UNFOLLOW = "unfollow";
 export const POST_OVR_WEIGHT = 0.7;
 export const POPULARITY_OVR_WEIGHT = 0.3;
 export const NO_CORRELATION = 0.0;
+
+export const RECENCY_CUTOFF_IN_DAYS = 2;


### PR DESCRIPTION
## Overview (Largely ported from [TC2 documentation](https://docs.google.com/document/d/1kNEz32Xm4RZwRLB867fBea2WWoBEhev3rD0eiksIfTs/edit?tab=t.0#heading=h.wxdbm3cim1iu))
1) Added new _suggestedUsers_ column in User model
-- Contains _Object_ { _String_ userID: _Date_ lastSuggestedDate , … }
-- Set of suggested users mapped to date they were suggested

2) When we suggest a user in **notifyUsers**,  we now update the user’s _suggestedUsers_ column to append a new suggestion instance

3) In the **evaluateCandidate** function:
-- Implemented a two day timeout for recently suggested candidates
-- If a user’s _suggestedUsers_ contains the candidate and it has been less than two days since _lastSuggestedDate_, skip evaluation by returning _-Inf_ as score
-- If it’s been longer than two days, release the candidate from timeout by removing them from user's _suggestedUsers_ in DB and proceed with evaluation

4) [MISC] When a user follows someone, remove them from the user's _suggestedUsers_ if they're present in it

## Test Plan
### Process of Elimination (POE) Live Test - [Video Confirming Success](https://www.loom.com/share/4658ff09294f41018b1495a17cecf5ac?sid=de735554-e3cb-42fe-91bd-ff5c123b6652)
- Remove the best time allowance window so we are guaranteed a notification firing on cron job occurrence
- Add a test socket message that fires to the client when there are no users to display (i.e. every other user has already been suggested recently)
- Initialize an instance of the client by signing in. If all logic is sound, then the user will be suggested someone new each job occurrence, eventually receiving the fallback test socket message when all users have been suggested

### Post-POE Follow Test For Item 4
- Fired a message to server console if user follows someone who is in their _suggestedUsers_, prompting a removal and update in DB
<img width="724" height="53" alt="image" src="https://github.com/user-attachments/assets/7f6a1dc4-373f-4d94-a69c-cd7375f3cabd" />


