### PR TITLE
[TC2][Stretch] Iteration on Profile Ranking - New Metrics to Consider

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@google-cloud/storage": "^7.16.0",
         "bcryptjs": "^3.0.2",
+        "compute-cosine-similarity": "^1.1.0",
         "get-video-duration": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.1",
@@ -689,6 +690,38 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compute-cosine-similarity": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-cosine-similarity/-/compute-cosine-similarity-1.1.0.tgz",
+      "integrity": "sha512-FXhNx0ILLjGi9Z9+lglLzM12+0uoTnYkHm7GiadXDAr0HGVLm25OivUS1B/LPkbzzvlcXz/1EvWg9ZYyJSdhTw==",
+      "dev": true,
+      "dependencies": {
+        "compute-dot": "^1.1.0",
+        "compute-l2norm": "^1.1.0",
+        "validate.io-array": "^1.0.5",
+        "validate.io-function": "^1.0.2"
+      }
+    },
+    "node_modules/compute-dot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-dot/-/compute-dot-1.1.0.tgz",
+      "integrity": "sha512-L5Ocet4DdMrXboss13K59OK23GXjiSia7+7Ukc7q4Bl+RVpIXK2W9IHMbWDZkh+JUEvJAwOKRaJDiFUa1LTnJg==",
+      "dev": true,
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2"
+      }
+    },
+    "node_modules/compute-l2norm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-l2norm/-/compute-l2norm-1.1.0.tgz",
+      "integrity": "sha512-6EHh1Elj90eU28SXi+h2PLnTQvZmkkHWySpoFz+WOlVNLz3DQoC4ISUHSV9n5jMxPHtKGJ01F4uu2PsXBB8sSg==",
+      "dev": true,
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1207,15 +1240,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
-      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -3091,6 +3125,19 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ==",
+      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@google-cloud/storage": "^7.16.0",
     "bcryptjs": "^3.0.2",
+    "compute-cosine-similarity": "^1.1.0",
     "get-video-duration": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -61,3 +61,10 @@ export const POPULARITY_OVR_WEIGHT = 0.3;
 export const NO_CORRELATION = 0.0;
 
 export const RECENCY_CUTOFF_IN_DAYS = 2;
+
+export const RELEVANCY_CUTOFF = 5;
+export const MEANINFUL_INTERACTION_BONUS = 3;
+export const LIKE_POINT_VALUE = 1;
+export const COMMENT_POINT_VALUE = 3;
+export const INTERACTION_POINTS_THRESHOLD = 4;
+export const USER_TIMING_BONUS = 2;

--- a/server/utils/profileRankingUtils.js
+++ b/server/utils/profileRankingUtils.js
@@ -1,6 +1,20 @@
 import { PrismaClient } from "../generated/prisma/index.js";
-import { RANKING_MODES, POST_OVR_WEIGHT, POPULARITY_OVR_WEIGHT, NO_CORRELATION, MILLISECONDS_IN_DAY, RECENCY_CUTOFF_IN_DAYS } from "./constants.js";
+import {
+    RANKING_MODES,
+    POST_OVR_WEIGHT,
+    POPULARITY_OVR_WEIGHT,
+    NO_CORRELATION,
+    MILLISECONDS_IN_DAY,
+    RECENCY_CUTOFF_IN_DAYS,
+    RELEVANCY_CUTOFF,
+    MEANINFUL_INTERACTION_BONUS,
+    LIKE_POINT_VALUE,
+    COMMENT_POINT_VALUE,
+    INTERACTION_POINTS_THRESHOLD,
+    USER_TIMING_BONUS,
+} from "./constants.js";
 import { scorePosts } from "./serverPostRecommendationUtils.js";
+import similarity from "compute-cosine-similarity";
 
 const prisma = new PrismaClient();
 
@@ -11,9 +25,7 @@ export const rankCandidates = async (hostUserID) => {
     delete user.password;
 
     let candidates = await prisma.user.findMany({
-        // for when we have a following list
-        //where: { userID: { notIn: user.followedUsers } },
-        where: { userID: { not: hostUserID } },
+        where: { userID: { not: hostUserID, notIn: user.followedUsers } },
     });
 
     for (const candidate of candidates) {
@@ -27,7 +39,7 @@ export const rankCandidates = async (hostUserID) => {
     return candidates;
 };
 
-// Evaluate a suggestion candidate for a user based on their posts score, interests similarity, and mutual following
+// Evaluate a suggestion candidate for a user based on outlined metrics
 const evaluateCandidate = async (user, candidate) => {
     if (!user || !candidate) {
         console.log("evaluateCandidate: user or candidate is null");
@@ -40,22 +52,29 @@ const evaluateCandidate = async (user, candidate) => {
         return -Infinity;
     }
 
-    // Rank posts using created recommendation algorithm
-    const { postOvr, popularityOvr } = await computeCandidatePostMetrics(user, candidate);
+    // 0) Rank candidate's posts using created recommendation algorithm and set base score
+    // 1) Gauge if the user interacts with the candidate's in a meaningful capacity
+    const { postOvr, popularityOvr, meaningfulInteractionBonus } = await computeCandidatePostMetrics(user, candidate);
 
     const baseScore = postOvr * POST_OVR_WEIGHT + popularityOvr * POPULARITY_OVR_WEIGHT;
 
-    // Compute the similarity score between the users
+    // 2A) Compute the similarity score between the users
     const cosineSimilarityScore = await computeSimilarityScore(user, candidate);
 
-    // Convert the similarity score to a scalar factor
+    // 2B) Convert the similarity score to a scalar factor
     const similarityFactor = (1 + Math.abs(cosineSimilarityScore)) * (cosineSimilarityScore < 0 ? -1 : 1);
 
-    // Find the mutual following frequency between the users
+    // 3) Find the mutual following frequency between the users
     const mutualFollowFrequency = computeMutualFollowingFrequency(user, candidate);
 
+    // 4) Apply a bonus contingent to how closely the user and candidate's app usage aligns
+    const userTimingBonus = await computeUserTimingBonus(user, candidate);
+
+    // Combine the bonuses
+    const bonuses = meaningfulInteractionBonus + userTimingBonus;
+
     // Finalize and return the candidate's score
-    const candidateScore = baseScore * similarityFactor * (1 + mutualFollowFrequency);
+    const candidateScore = baseScore * similarityFactor * (1 + mutualFollowFrequency) + bonuses;
     return candidateScore;
 };
 
@@ -65,21 +84,21 @@ const checkSuggestionsEligibility = async (user, candidate) => {
     const recentlySuggestedUsers = user.suggestedUsers;
     const lastSuggestedDate = recentlySuggestedUsers[candidate.userID] || null;
 
-    // If the candidate was recently suggested check, if they're eligible for re-suggestion
-    if (lastSuggestedDate) {
-        const daysSinceLastSuggested = (Date.now() - new Date(lastSuggestedDate)) / MILLISECONDS_IN_DAY;
+    if (!lastSuggestedDate) return true;
 
-        // Too soon
-        if (daysSinceLastSuggested < RECENCY_CUTOFF_IN_DAYS) {
-            return false;
-        }
+    // If the candidate was recently suggested, check if they're eligible for re-suggestion
+    const daysSinceLastSuggested = (Date.now() - new Date(lastSuggestedDate)) / MILLISECONDS_IN_DAY;
 
-        // It's been long enough, remove the candidate from the recently suggested list
-        else {
-            delete recentlySuggestedUsers[candidate.userID];
-            await prisma.user.update({ where: { userID: user.userID }, data: { suggestedUsers: recentlySuggestedUsers } });
-            return true;
-        }
+    // Too soon
+    if (daysSinceLastSuggested < RECENCY_CUTOFF_IN_DAYS) {
+        return false;
+    }
+
+    // It's been long enough, remove the candidate from the recently suggested list
+    else {
+        delete recentlySuggestedUsers[candidate.userID];
+        await prisma.user.update({ where: { userID: user.userID }, data: { suggestedUsers: recentlySuggestedUsers } });
+        return true;
     }
 };
 
@@ -88,20 +107,25 @@ const computeCandidatePostMetrics = async (user, candidate) => {
     const candidatePosts = await prisma.post.findMany({ where: { authorID: candidate.userID } });
     let postOvr = 0;
     let popularityOvr = 0;
-    if (candidatePosts.length > 0) {
-        // Average post scores an overall posts score
-        let rankedCandidatePosts = await scorePosts(candidatePosts, user, RANKING_MODES.RECOMMENDED);
-        let totalScore = 0;
-        let totalPopularity = 0;
-        for (const post of rankedCandidatePosts) {
-            totalScore += post.score;
-            totalPopularity += post.popularity;
-        }
-        postOvr = totalScore / candidatePosts.length;
-        popularityOvr = totalPopularity / candidatePosts.length;
-    }
+    let meaningfulInteractionBonus = 0;
 
-    return { postOvr, popularityOvr };
+    // Return early if candidate has no posts
+    if (candidatePosts.length === 0) return { postOvr, popularityOvr, meaningfulInteractionBonus };
+
+    meaningfulInteractionBonus = await computeMeaningfulInteractionBonus(user, candidatePosts);
+
+    // Average post scores as an overall posts score
+    let rankedCandidatePosts = await scorePosts(candidatePosts, user, RANKING_MODES.RECOMMENDED);
+    let totalScore = 0;
+    let totalPopularity = 0;
+    for (const post of rankedCandidatePosts) {
+        totalScore += post.score;
+        totalPopularity += post.popularity;
+    }
+    postOvr = totalScore / candidatePosts.length;
+    popularityOvr = totalPopularity / candidatePosts.length;
+
+    return { postOvr, popularityOvr, meaningfulInteractionBonus };
 };
 
 // Vectorize the users' frequency objects and performs a cosine similarity comparison to get a similarity score
@@ -149,4 +173,77 @@ const computeMutualFollowingFrequency = (user, candidate) => {
     const mutualFollowFrequency = followingUnion.size === 0 ? 0 : followingOverlap.length / followingUnion.size;
 
     return mutualFollowFrequency;
+};
+
+// Gagues if the user has interacted with a candidate's recent posts in a meaningful capacity
+// Returns a constant to add to the candidate's score
+const computeMeaningfulInteractionBonus = async (user, candidatePosts) => {
+    // TLDR: Sort candidate's posts by date and pick the RELEVANCY_CUTOFF most recent
+    const postsToAssess = candidatePosts.toSorted((a, b) => new Date(b.creationDate) - new Date(a.creationDate)).slice(0, RELEVANCY_CUTOFF);
+
+    // Init post interactions tally
+    let userLikesTally = 0;
+    let userCommentsTally = 0;
+
+    for (const post of postsToAssess) {
+        if (user.likedPosts.includes(post.postID)) userLikesTally++;
+
+        const userCommentsOnPost = await prisma.comment.findMany({ where: { commentID: { in: post.comments }, authorID: user.userID } });
+        userCommentsTally += userCommentsOnPost.length;
+    }
+
+    const totalInteractionPoints = userLikesTally * LIKE_POINT_VALUE + userCommentsTally + COMMENT_POINT_VALUE;
+    return totalInteractionPoints >= INTERACTION_POINTS_THRESHOLD ? MEANINFUL_INTERACTION_BONUS : 0;
+};
+
+// Produces a vector for user and candidate consisting of session and interaction metrics
+// Using the vectors' cosine similarity score, returns constant to add to the candidate's score
+const computeUserTimingBonus = async (user, candidate) => {
+    const userAppUsageVector = await createAppUsageVector(user);
+    const candidateAppUsageVector = await createAppUsageVector(candidate);
+
+    const cosineSimilarityScore = similarity(userAppUsageVector, candidateAppUsageVector);
+
+    // Comparison is inapplicable or vectors are inferred to be opposing in nature, don't apply the bonus
+    if (!cosineSimilarityScore || cosineSimilarityScore < 0) return 0;
+
+    // Scale the user timing bonus to the vectors' similarity
+    return USER_TIMING_BONUS * (1 + cosineSimilarityScore);
+};
+
+// Generates a user's app usage vector based on session and interaction metrics, returns vector as array
+const createAppUsageVector = async (user) => {
+    const userSessionData = await prisma.sessionData.findUnique({ where: { userID: user.userID } });
+    const userInteractionData = await prisma.interactionData.findUnique({ where: { userID: user.userID } });
+
+    const userAverageHighInteractionDensityTime = computeAverageHighInteractionDensityTime(userInteractionData);
+
+    // Abbreviate to reduce clutter
+    const u_S_D = userSessionData;
+    const userAppUsageVector = [u_S_D.averageSessionStartTime, u_S_D.averageSessionTime, userAverageHighInteractionDensityTime];
+
+    return userAppUsageVector;
+};
+
+// Returns average high interaction density time for provided user interaction data
+const computeAverageHighInteractionDensityTime = (interactionData) => {
+    // Abbreviate in these calculations to mitigate clutter
+    const i_D = interactionData;
+
+    const hasLiked = i_D.likeInteractionCount > 0 ? 1 : 0;
+    const hasCommented = i_D.commentInteractionCount > 0 ? 1 : 0;
+    const hasCreated = i_D.createInteractionCount > 0 ? 1 : 0;
+
+    const userTotalInteractionFields = hasLiked + hasCommented + hasCreated;
+
+    // No point in proceeding
+    if (userTotalInteractionFields === 0) return 0;
+
+    const inUseAverageLikeInteractionTime = hasLiked * i_D.averageLikeInteractionTime;
+    const inUseAverageCommentInteractionTime = hasCommented * i_D.averageCommentInteractionTime;
+    const inUseAverageCreateInteractionTime = hasCreated * i_D.averageCreateInteractionTime;
+
+    const userTimesAggregate = inUseAverageLikeInteractionTime + inUseAverageCommentInteractionTime + inUseAverageCreateInteractionTime;
+
+    return Math.ceil(userTimesAggregate / userTotalInteractionFields);
 };


### PR DESCRIPTION
## Context - Stretch Goal Documentation
Document ["Sk8rlog Planning" ](https://docs.google.com/document/d/1w-cblWeSteRe4uhV08d3gxD7hggLu-YP3gZbIwz27wk/edit?usp=sharing)→ Stretch Goals → [More Metrics](https://docs.google.com/document/d/1w-cblWeSteRe4uhV08d3gxD7hggLu-YP3gZbIwz27wk/edit?tab=t.0#heading=h.gmpabj78fy1w) → [TC2] Additional considerations when ranking a profile

## Overview
Implemented additional factors in the profile ranking algorithm pursuant to ideas discussed in documentation. New considerations that have been translated to numerical values include:
- A) A user does not follow the candidate but interacts with their posts in a meaningful capacity
- B) The user and candidate use the app at similar times

See link to documentation for details of implementation

## Test Plan
### Process of Elimination (POE) Live Test - [Video Confirming Success](https://www.loom.com/share/e8884d572a154a20b45f10879ca26356?sid=d27f7db5-e580-4b84-a85d-9b739a09dc76)
Remove the best time allowance window so we are guaranteed a notification firing on cron job occurrence

Add a test socket message that fires to the client when there are no users to display (i.e. every other user has already been suggested recently)

Initialize an instance of the client by signing in to some **user**. If all logic is sound, then
* the **user** will be suggested someone new each job occurrence
* the server console will log generated total interaction points / meaningful interaction bonus (A) and user timing bonus (B) for each candidate as applicable and these values will show variation in some capacity across some candidates
* the client will eventually receive the fallback test socket message when all users have been suggested