### PR TITLE
[TC1][TC2][Stretch] Implemented Locations as a Factor in Ranking

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "bcryptjs": "^3.0.2",
         "compute-cosine-similarity": "^1.1.0",
         "get-video-duration": "^4.1.0",
+        "haversine": "^1.1.1",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.1",
         "node-cron": "^4.2.1",
@@ -1592,6 +1593,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/haversine": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/haversine/-/haversine-1.1.1.tgz",
+      "integrity": "sha512-KW4MS8+krLIeiw8bF5z532CptG0ZyGGFj0UbKMxx25lKnnJ1hMUbuzQl+PXQjNiDLnl1bOyz23U6hSK10r4guw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-entities": {
       "version": "2.6.0",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     "bcryptjs": "^3.0.2",
     "compute-cosine-similarity": "^1.1.0",
     "get-video-duration": "^4.1.0",
+    "haversine": "^1.1.1",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",
     "node-cron": "^4.2.1",

--- a/server/utils/calculateProximityBias.js
+++ b/server/utils/calculateProximityBias.js
@@ -1,0 +1,20 @@
+import haversine from "haversine";
+import { LOCATIONS, LOCATIONS_COORDINATES, BASE_PROXIMITY_BIAS } from "./constants.js";
+
+// Calculates distance between two locations in km and generates a proximity bias score based on it
+const calculateProximityBias = (locationStringA, locationStringB) => {
+    if (locationStringA === LOCATIONS.DEFAULT || locationStringB === LOCATIONS.DEFAULT) return 0;
+    if (locationStringA === locationStringB) return BASE_PROXIMITY_BIAS;
+
+    const locationCoordinatesA = LOCATIONS_COORDINATES[locationStringA];
+    const locationCoordinatesB = LOCATIONS_COORDINATES[locationStringB];
+
+    const distanceInKM = haversine(locationCoordinatesA, locationCoordinatesB, { unit: "km" });
+
+    // Increases as distance closes, approaches zero as distance increaes
+    const proximityBias = BASE_PROXIMITY_BIAS / Math.sqrt(distanceInKM);
+
+    return proximityBias;
+};
+
+export default calculateProximityBias;

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -94,3 +94,27 @@ export const DELIVER_NOTIFICATION = "deliver notification";
 // DELIVER_NOTIFICATION subtypes
 export const USER_SUGGESTION = "user suggestion";
 export const POST_SUGGESTION = "post suggestion";
+
+/**********************************************/
+
+/* LOCATIONS */
+
+// Pool of locations the user could select from in registration
+const LOCATIONS = {
+    DEFAULT: "none",
+    MIA: "Miami",
+    SEA: "Seattle",
+    SFO: "San Francisco",
+    LAX: "Los Angeles",
+    NYC: "New York City",
+};
+
+// Locations mapped to coordinates for distance calculations
+export const LOCATIONS_COORDINATES = {
+    [LOCATIONS.DEFAULT]: { latitude: 0, longitude: 0 },
+    [LOCATIONS.MIA]: { latitude: 25.782, longitude: -80.193 },
+    [LOCATIONS.SEA]: { latitude: 47.6062, longitude: -122.3321 },
+    [LOCATIONS.SFO]: { latitude: 37.6213, longitude: -122.379 },
+    [LOCATIONS.LAX]: { latitude: 34.0522, longitude: -118.2437 },
+    [LOCATIONS.NYC]: { latitude: 40.73061, longitude: -73.935242 },
+};

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -100,7 +100,7 @@ export const POST_SUGGESTION = "post suggestion";
 /* LOCATIONS */
 
 // Pool of locations the user could select from in registration
-const LOCATIONS = {
+export const LOCATIONS = {
     DEFAULT: "none",
     MIA: "Miami",
     SEA: "Seattle",
@@ -118,3 +118,6 @@ export const LOCATIONS_COORDINATES = {
     [LOCATIONS.LAX]: { latitude: 34.0522, longitude: -118.2437 },
     [LOCATIONS.NYC]: { latitude: 40.73061, longitude: -73.935242 },
 };
+
+// Default proximity bias when distance is 0
+export const BASE_PROXIMITY_BIAS = 2;

--- a/server/utils/postRecommendations/calculateSinglePostScore.js
+++ b/server/utils/postRecommendations/calculateSinglePostScore.js
@@ -82,7 +82,6 @@ const calculateSinglePostScore = async (
 
     // Calculate proximity bias as constant factor added to overall score
     const proximityBias = calculateProximityBias(userLocation, post.location);
-    console.log(`distance between ${userLocation} and ${post.location}, proximityBias is ${proximityBias}`);
 
     // Apply relative interest factor and bias factor to raw post score to get the final score
     const finalScore = rawPostScore * relativeInterestFactor * biasFactor + proximityBias;

--- a/server/utils/postRecommendations/calculateSinglePostScore.js
+++ b/server/utils/postRecommendations/calculateSinglePostScore.js
@@ -3,6 +3,7 @@ import calculateBiasFactors from "./helpers/calculateBiasFactors.js";
 import filterTokens from "./helpers/filterTokens.js";
 import calculateTokenScore from "./helpers/calculateTokenScore.js";
 import getPostLength from "./helpers/getPostLength.js";
+import calculateProximityBias from "../calculateProximityBias.js";
 
 // Wrapper function for calculateSinglePostScore > takes in a user obj as argument to generate full set of params
 // Used in the post notifications flow
@@ -10,8 +11,16 @@ export const calculateSinglePostScoreWithUserObject = async (post, user) => {
     const userFrequency = user.user_Frequency;
     const { portionOfLikedPostsThatAreClips, avgLengthOfLikedPosts } = await calculateBiasFactors(user);
     const portionOfLikedPostsThatAreBlogs = 1 - portionOfLikedPostsThatAreClips;
+    const userLocation = user.location;
 
-    await calculateSinglePostScore(post, userFrequency, avgLengthOfLikedPosts, portionOfLikedPostsThatAreClips, portionOfLikedPostsThatAreBlogs);
+    await calculateSinglePostScore(
+        post,
+        userFrequency,
+        avgLengthOfLikedPosts,
+        portionOfLikedPostsThatAreClips,
+        portionOfLikedPostsThatAreBlogs,
+        userLocation
+    );
 };
 
 // Calculates a post's score and assigns it to the provided post object
@@ -20,7 +29,8 @@ const calculateSinglePostScore = async (
     userFrequency,
     avgLengthOfLikedPosts,
     portionOfLikedPostsThatAreClips,
-    portionOfLikedPostsThatAreBlogs
+    portionOfLikedPostsThatAreBlogs,
+    userLocation
 ) => {
     let rawPostScore = 0;
 
@@ -70,8 +80,12 @@ const calculateSinglePostScore = async (
     // Calculate bias factor as popularity amplified by type bias and inhibited by disparity from average post length
     const biasFactor = popularityScore * (1 + typeBias) * postLengthBias;
 
+    // Calculate proximity bias as constant factor added to overall score
+    const proximityBias = calculateProximityBias(userLocation, post.location);
+    console.log(`distance between ${userLocation} and ${post.location}, proximityBias is ${proximityBias}`);
+
     // Apply relative interest factor and bias factor to raw post score to get the final score
-    const finalScore = rawPostScore * relativeInterestFactor * biasFactor;
+    const finalScore = rawPostScore * relativeInterestFactor * biasFactor + proximityBias;
     post["score"] = finalScore;
     post["popularity"] = popularityScore;
 };

--- a/server/utils/postRecommendations/scorePosts.js
+++ b/server/utils/postRecommendations/scorePosts.js
@@ -20,8 +20,18 @@ const scorePosts = async (posts, activeUser, scoringMode) => {
     const { portionOfLikedPostsThatAreClips, avgLengthOfLikedPosts } = await calculateBiasFactors(activeUser);
     const portionOfLikedPostsThatAreBlogs = 1 - portionOfLikedPostsThatAreClips;
 
+    // Grab user's location for proximity biasing
+    const userLocation = activeUser.location;
+
     for (const post of posts) {
-        await calculateSinglePostScore(post, userFrequency, avgLengthOfLikedPosts, portionOfLikedPostsThatAreClips, portionOfLikedPostsThatAreBlogs);
+        await calculateSinglePostScore(
+            post,
+            userFrequency,
+            avgLengthOfLikedPosts,
+            portionOfLikedPostsThatAreClips,
+            portionOfLikedPostsThatAreBlogs,
+            userLocation
+        );
     }
 
     // Sort posts by either recommendation score or popularity

--- a/server/utils/profileRanking/evaluateCandidate.js
+++ b/server/utils/profileRanking/evaluateCandidate.js
@@ -4,6 +4,7 @@ import computeCandidatePostMetrics from "./helpers/computeCandidatePostMetrics.j
 import computeSimilarityScore from "./helpers/computeSimilarityScore.js";
 import computeMutualFollowingFrequency from "./helpers/computeMutualFollowingFrequency.js";
 import computeUserTimingBonus from "./helpers/computeUserTimingBonus.js";
+import calculateProximityBias from "../calculateProximityBias.js";
 
 // Evaluate a suggestion candidate for a user based on outlined metrics
 const evaluateCandidate = async (user, candidate) => {
@@ -36,8 +37,11 @@ const evaluateCandidate = async (user, candidate) => {
     // 4) Apply a bonus contingent to how closely the user and candidate's app usage aligns
     const userTimingBonus = await computeUserTimingBonus(user, candidate);
 
+    // 5) Apply a bonus corresponding to the user's proximity to the candidate
+    const proximityBonus = calculateProximityBias(user.location, candidate.location);
+
     // Combine the bonuses
-    const bonuses = meaningfulInteractionBonus + userTimingBonus;
+    const bonuses = meaningfulInteractionBonus + userTimingBonus + proximityBonus;
 
     // Finalize and return the candidate's score
     const candidateScore = baseScore * similarityFactor * (1 + mutualFollowFrequency) + bonuses;


### PR DESCRIPTION
## Overview
Implemented a function that:
- maps user/post locations to coordinates and performs spherical distance calculations using the Haversine formula
- uses this distance in a rational square root function to generate a proximity bias factor applied to either a user-post evaluation or a user-candidate evaluation, effectively integrating this functionality into the post recommendation algorithm / notification system and profile ranking / notification system

## Test Plan
Leveraged the previously implemented post notifications feature (#43) to actively log proximity bias calculation results to the console when a new post gets evaluated for every user. All outputs are in alignment with intended results of calculations:

<img width="863" height="182" alt="image" src="https://github.com/user-attachments/assets/68b5459b-a45f-4208-8908-9db20a543aa6" />

Bias factor is in play when automatically scoring posts for Home/Clips/Blogs pages
<img width="1228" height="240" alt="image" src="https://github.com/user-attachments/assets/32eb8a28-991e-45e5-8812-ac1983c54eb7" />

