### PR TITLE
[Not For Eval][TC1][Stretch] Post Length Gets Stored on Creation

### DIFF
--- a/client/src/main/Modals/CreatePostModal.jsx
+++ b/client/src/main/Modals/CreatePostModal.jsx
@@ -11,6 +11,8 @@ const CreatePostModal = ({ activeUser, toggleCreatePostModal, setIsOutdated }) =
 
     const [postType, setPostType] = useState(POST_TYPE_DEFAULT);
 
+    const [uploadButtonText, setUploadButtonText] = useState("Upload");
+
     const handleForm = async (formData) => {
         await uploadPost(postType, formData, activeUser, socket);
         setIsOutdated(true);
@@ -54,7 +56,16 @@ const CreatePostModal = ({ activeUser, toggleCreatePostModal, setIsOutdated }) =
                     </>
                 )}
 
-                {postType !== POST_TYPE_DEFAULT && <button type="submit">Upload</button>}
+                {postType !== POST_TYPE_DEFAULT && (
+                    <button
+                        type="submit"
+                        onClick={() => {
+                            setUploadButtonText("Uploading...");
+                        }}
+                    >
+                        {uploadButtonText}
+                    </button>
+                )}
             </form>
         </section>
     );

--- a/client/src/main/PostCard.jsx
+++ b/client/src/main/PostCard.jsx
@@ -1,7 +1,7 @@
 import { useRef, useContext, useEffect, useState } from "react";
 import { Link } from "react-router";
 
-import { deletePost, waitForGCSToFinish } from "/src/utils/postUtils/postDataUtils";
+import { deletePost } from "/src/utils/postUtils/postDataUtils";
 import { handleLikeOrUnlikePost } from "/src/utils/postUtils/postInteractionUtils";
 
 import UserContext from "/src/utils/UserContext";
@@ -17,12 +17,6 @@ const PostCard = ({ post, postType, origin, profileID = PROFILE_ORIGIN_NOT_APPLI
     const { activeUser, setActiveUser } = useContext(UserContext);
 
     const embedRef = useRef(null);
-
-    const [fileIsLoaded, setFileIsLoaded] = useState(false);
-
-    const wait = async () => {
-        await waitForGCSToFinish(post.fileURL, setFileIsLoaded);
-    };
 
     const onEnter = () => {
         embedRef.current.play();
@@ -41,23 +35,9 @@ const PostCard = ({ post, postType, origin, profileID = PROFILE_ORIGIN_NOT_APPLI
         handleLikeOrUnlikePost(event, post, action, activeUser, setActiveUser);
     };
 
-    useEffect(() => {
-        if (!fileIsLoaded) {
-            wait();
-        }
-    }, []);
-
     if (!post) {
         console.error("Post failed to load");
         return;
-    }
-
-    if (!fileIsLoaded) {
-        return (
-            <article className={`${postType}PostCard`}>
-                <p>Loading...</p>
-            </article>
-        );
     }
 
     return (

--- a/client/src/utils/postUtils/postDataUtils.js
+++ b/client/src/utils/postUtils/postDataUtils.js
@@ -55,29 +55,3 @@ export const deletePost = async (post, setUserPosts) => {
         console.error("deletePost/File: ", error);
     });
 };
-
-// Timeout for GCS to finish uploading file
-export const waitForGCSToFinish = async (fileURL, setFileIsLoaded) => {
-    const fetchInterval = 500;
-
-    const checkForFile = async () => {
-        try {
-            // Use HEAD to prevent download
-            const res = await fetch(fileURL, { method: "HEAD" }).catch((error) => {
-                /* Do nothing, keep trying */
-            });
-            if (res.ok) {
-                setFileIsLoaded(true);
-                return;
-            }
-        } catch (error) {
-            /* Do nothing, keep trying */
-        }
-
-        setTimeout(() => {
-            return checkForFile();
-        }, fetchInterval);
-    };
-
-    return await checkForFile();
-};

--- a/server/prisma/migrations/20250728183639_length_official/migration.sql
+++ b/server/prisma/migrations/20250728183639_length_official/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `clipLength` on the `Post` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Post" DROP COLUMN "clipLength",
+ADD COLUMN     "length" INTEGER;

--- a/server/prisma/migrations/20250728184924_length_required/migration.sql
+++ b/server/prisma/migrations/20250728184924_length_required/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `length` on table `Post` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Post" ALTER COLUMN "length" SET NOT NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -39,7 +39,7 @@ model Post {
   location          String
   type              String
   fileURL           String
-  clipLength        Float?
+  length            Int
   likeCount         Int     @default(0)
   comments          String[]  @default([])
 }

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -6,6 +6,7 @@ const recalculateInteractionAverages = require("../utils/sessions/recalculateInt
 const scorePosts = require("../utils/postRecommendations/scorePosts").default;
 const { uploadFile, deleteFile } = require("../utils/googleCloudStorageUtils");
 const getPostLength = require("../utils/postRecommendations/helpers/getPostLength").default;
+const { waitForGCSToFinish } = require("../utils/googleCloudStorageUtils");
 
 const Multer = require("multer");
 const multer = Multer({
@@ -45,6 +46,10 @@ router.post("/uploadFile", multer.single("postFile"), async (req, res, _next) =>
         const DESTINATION = `${crypto.randomUUID()}.${extension}`;
         const objectURL = await uploadFile(req.file, DESTINATION);
 
+        console.log("calling waitForGCSToFinish");
+        await waitForGCSToFinish(objectURL);
+        console.log("done with GCS");
+
         return res.status(STATUS_CODES.CREATED).json({ fileURL: objectURL, message: "File uploaded" });
     } catch (error) {
         return res.status(STATUS_CODES.SERVER_ERROR).json({ message: error });
@@ -57,6 +62,10 @@ router.post("/create/:userID", async (req, res, _next) => {
     try {
         const { userID } = req.params;
         const { textContent, location, postType, fileURL } = req.body;
+        console.log(textContent, location, postType, fileURL);
+        console.log("getting post length");
+        const postLength = await getPostLength({ description: textContent, type: postType, fileURL });
+        console.log(`Post length: ${postLength}`);
 
         const post = await prisma.post.create({
             data: {
@@ -65,6 +74,7 @@ router.post("/create/:userID", async (req, res, _next) => {
                 location,
                 type: postType,
                 fileURL,
+                length: postLength,
             },
         });
 

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -1,7 +1,7 @@
 const { PrismaClient } = require("../generated/prisma");
 const router = require("express").Router();
 const STATUS_CODES = require("../statusCodes");
-const { QUICKTIME, MOV, COMMENT, CREATE } = require("../utils/constants");
+const { QUICKTIME, MOV, COMMENT, CREATE, GCS_CHECK_INTERVAL } = require("../utils/constants");
 const recalculateInteractionAverages = require("../utils/sessions/recalculateInteractionAverages").default;
 const scorePosts = require("../utils/postRecommendations/scorePosts").default;
 const { uploadFile, deleteFile } = require("../utils/googleCloudStorageUtils");
@@ -46,9 +46,12 @@ router.post("/uploadFile", multer.single("postFile"), async (req, res, _next) =>
         const DESTINATION = `${crypto.randomUUID()}.${extension}`;
         const objectURL = await uploadFile(req.file, DESTINATION);
 
-        console.log("calling waitForGCSToFinish");
-        await waitForGCSToFinish(objectURL);
-        console.log("done with GCS");
+        // 'False' as in the URL is not ready yet, 'True' as in the URL is ready
+        while ((await waitForGCSToFinish(objectURL)) === false) {
+            setTimeout(async () => {
+                await waitForGCSToFinish(objectURL);
+            }, GCS_CHECK_INTERVAL);
+        }
 
         return res.status(STATUS_CODES.CREATED).json({ fileURL: objectURL, message: "File uploaded" });
     } catch (error) {
@@ -62,10 +65,7 @@ router.post("/create/:userID", async (req, res, _next) => {
     try {
         const { userID } = req.params;
         const { textContent, location, postType, fileURL } = req.body;
-        console.log(textContent, location, postType, fileURL);
-        console.log("getting post length");
         const postLength = await getPostLength({ description: textContent, type: postType, fileURL });
-        console.log(`Post length: ${postLength}`);
 
         const post = await prisma.post.create({
             data: {

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -5,6 +5,7 @@ const { QUICKTIME, MOV, COMMENT, CREATE } = require("../utils/constants");
 const recalculateInteractionAverages = require("../utils/sessions/recalculateInteractionAverages").default;
 const scorePosts = require("../utils/postRecommendations/scorePosts").default;
 const { uploadFile, deleteFile } = require("../utils/googleCloudStorageUtils");
+const getPostLength = require("../utils/postRecommendations/helpers/getPostLength").default;
 
 const Multer = require("multer");
 const multer = Multer({

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -7,6 +7,9 @@ export const MOV = "mov";
 // Used across recommendation utilities to drop values as needed
 export const NOT_APPLICABLE = -1;
 
+// Timeout for waitForGCSToFinish
+export const GCS_CHECK_INTERVAL = 500;
+
 /**********************************************/
 
 /* TIME */

--- a/server/utils/googleCloudStorageUtils.js
+++ b/server/utils/googleCloudStorageUtils.js
@@ -72,29 +72,15 @@ export const deleteFile = async (fileURL) => {
 
 // Timeout for GCS to finish uploading file on post creation
 export const waitForGCSToFinish = async (fileURL) => {
-    console.log("entered wfGCS");
-    const fetchInterval = 500;
+    const res = await fetch(fileURL, { method: "HEAD" }).catch((error) => {
+        console.error("waitForGCSToFinish: video URL fetch outright failed");
+    });
 
-    const checkForFile = async () => {
-        try {
-            // Use HEAD to prevent download
-            const res = await fetch(fileURL, { method: "HEAD" }).catch((error) => {
-                /* Do nothing, keep trying */
-                console.log("not ready yet");
-            });
-            if (res.ok) {
-                /* Ready */
-                console.log("ready");
-                return;
-            }
-        } catch (error) {
-            /* Do nothing, keep trying */
-        }
-
-        setTimeout(async () => {
-            return await checkForFile();
-        }, fetchInterval);
-    };
-
-    return await checkForFile();
+    if (res.ok) {
+        /* Ready */
+        return true;
+    } else {
+        /* Not ready yet */
+        return false;
+    }
 };

--- a/server/utils/googleCloudStorageUtils.js
+++ b/server/utils/googleCloudStorageUtils.js
@@ -69,3 +69,32 @@ export const deleteFile = async (fileURL) => {
         console.error(error);
     }
 };
+
+// Timeout for GCS to finish uploading file on post creation
+export const waitForGCSToFinish = async (fileURL) => {
+    console.log("entered wfGCS");
+    const fetchInterval = 500;
+
+    const checkForFile = async () => {
+        try {
+            // Use HEAD to prevent download
+            const res = await fetch(fileURL, { method: "HEAD" }).catch((error) => {
+                /* Do nothing, keep trying */
+                console.log("not ready yet");
+            });
+            if (res.ok) {
+                /* Ready */
+                console.log("ready");
+                return;
+            }
+        } catch (error) {
+            /* Do nothing, keep trying */
+        }
+
+        setTimeout(async () => {
+            return await checkForFile();
+        }, fetchInterval);
+    };
+
+    return await checkForFile();
+};

--- a/server/utils/notifications/notifyUsersWithCandidate.js
+++ b/server/utils/notifications/notifyUsersWithCandidate.js
@@ -7,7 +7,7 @@ const notifyUsersWithCandidate = async (usersToNotify, socketServer) => {
     usersToNotify.forEach(async (user) => {
         // Acquire candidates and pick out top candidate (first in array)
         const res = await fetch(`http://localhost:3000/recommendations/acquireCandidates/for/${user.userID}`).catch((error) => {
-            console.log(error);
+            console.error(error);
         });
         const candidates = await res.json();
 

--- a/server/utils/postRecommendations/calculateSinglePostScore.js
+++ b/server/utils/postRecommendations/calculateSinglePostScore.js
@@ -56,14 +56,10 @@ const calculateSinglePostScore = async (
         rawPostScore += tokenScore;
     }
 
-    // Get and save post length
-    let postLength = await getPostLength(post);
-    post["postLength"] = postLength;
-
     // Calculate post length bias based on percentage disparity from average length of liked posts
     let postLengthBias = 1;
     if (avgLengthOfLikedPosts !== NOT_APPLICABLE) {
-        const percentageLengthDisparity = Math.abs(1 - postLength / avgLengthOfLikedPosts) * 100;
+        const percentageLengthDisparity = Math.abs(1 - post.length / avgLengthOfLikedPosts) * 100;
         postLengthBias = 1 / Math.sqrt(percentageLengthDisparity);
     }
 

--- a/server/utils/postRecommendations/helpers/calculateClipVideoLengthAsWordCount.js
+++ b/server/utils/postRecommendations/helpers/calculateClipVideoLengthAsWordCount.js
@@ -4,7 +4,7 @@ import { AVERAGE_WORDS_READ_PER_SECOND } from "../../constants.js";
 // Calculate a clip's video length translated to a "word count" using the average reading speed
 const calculateClipVideoLengthAsWordCount = async (fileURL) => {
     const clipLength = await getVideoDurationInSeconds(fileURL).catch((error) => {
-        console.error(error);
+        console.error(`getVideoDurationInSeconds: failed`);
     });
     const clipLengthAsWordCount = Math.ceil(clipLength * AVERAGE_WORDS_READ_PER_SECOND);
     return clipLengthAsWordCount;

--- a/server/utils/postRecommendations/helpers/getPostLength.js
+++ b/server/utils/postRecommendations/helpers/getPostLength.js
@@ -6,7 +6,9 @@ const getPostLength = async (post) => {
     let postLength = new String(post.description).split(NON_ALPHANUMERIC_REGEX).length;
 
     if (post.type === CLIPS) {
-        postLength += await calculateClipVideoLengthAsWordCount(post.fileURL);
+        postLength += await calculateClipVideoLengthAsWordCount(post.fileURL).catch((error) => {
+            console.error("calculateClipVideoLengthAsWordCount: failed");
+        });
     }
 
     return postLength;

--- a/server/utils/profileRanking/evaluateCandidate.js
+++ b/server/utils/profileRanking/evaluateCandidate.js
@@ -9,7 +9,7 @@ import calculateProximityBias from "../calculateProximityBias.js";
 // Evaluate a suggestion candidate for a user based on outlined metrics
 const evaluateCandidate = async (user, candidate) => {
     if (!user || !candidate) {
-        console.log("evaluateCandidate: user or candidate is null");
+        console.error("evaluateCandidate: user or candidate is null");
         return NaN;
     }
 

--- a/server/utils/profileRanking/helpers/computeSimilarityScore.js
+++ b/server/utils/profileRanking/helpers/computeSimilarityScore.js
@@ -24,7 +24,7 @@ const computeSimilarityScore = async (user, candidate) => {
             cosineSimilarityScore = isNaN(data.cosineSimilarityScore) ? NO_CORRELATION : data.cosineSimilarityScore;
         })
         .catch((err) => {
-            console.log(err);
+            console.error(err);
             cosineSimilarityScore = 0;
         });
 


### PR DESCRIPTION
## Overview
### Key Features
As it stood, the post recommendation algorithm would calculate the length of each post on invocation, inclusive of processing the length of a video. This generated unneeded overhead when loading feeds, so to improve this:
- I moved utility _waitForGCSToFinish_ from the client to the server. This relates to waiting for a Google Cloud Storage URL's metadata to be ready before using it as a video's _src_ on a post card, so it made more sense to store this logic in the _/uploadFile_ endpoint
- _getPostLength_ now gets invoked on post creation (without metadata errors that would previously occur) and the result is stored in the post's new **length** column
- In the post recommendation algorithm, the **length** attribute of a post object is now referenced in calculations instead of invoking _getPostLength_

### Extras
- Since _waitForGCSToFinish_ is now invoked in the server, the client post creation modal remains on screen for an extra bit of time after the "Upload" button is clicked. To improve user experience, the text gets changed to "Uploading..." while it awaits server response

## Test Plan
[Video](https://github.com/user-attachments/assets/a4f2dec1-c867-4b88-b4f4-e0f0d70e0a0d) of updated post upload sequence
[Video](https://github.com/user-attachments/assets/53b9fdda-b54a-4796-ae13-f83cf3fe74e6) of loading Home feed (note that Clips and Blogs take much closer time to load now that length calculations are streamlined!)